### PR TITLE
Catch exceptions for missing online state

### DIFF
--- a/DaS-PC-MPChan/DSCM.vb
+++ b/DaS-PC-MPChan/DSCM.vb
@@ -275,18 +275,24 @@ Public Class DSCM
         End Try
 
         For Each Row In dgvRecentNodes.Rows
-            If onlineInfo(converter(Row.Cells("steamId").Value())) Then
-                Row.Cells("isOnline").Value = "Y"
-            Else
-                Row.Cells("isOnline").Value = "N"
-            End If
+            Try
+                If onlineInfo(converter(Row.Cells("steamId").Value())) Then
+                    Row.Cells("isOnline").Value = "Y"
+                Else
+                    Row.Cells("isOnline").Value = "N"
+                End If
+            Catch ex As KeyNotFoundException
+            End Try
         Next
         For Each Row In dgvFavoriteNodes.Rows
-            If onlineInfo(converter(Row.Cells("steamId").Value())) Then
-                Row.Cells("isOnline").Value = "Y"
-            Else
-                Row.Cells("isOnline").Value = "N"
-            End If
+            Try
+                If onlineInfo(converter(Row.Cells("steamId").Value())) Then
+                    Row.Cells("isOnline").Value = "Y"
+                Else
+                    Row.Cells("isOnline").Value = "N"
+                End If
+            Catch ex As KeyNotFoundException
+            End Try
         Next
     End Sub
     Private Sub updatecheck()


### PR DESCRIPTION
Quickfix for this error: http://steamcommunity.com/app/211420/discussions/0/364039785166582725/?tscn=1461686531#c364039785168832572

The root of this problem is that the steam api limits requests to 100 ids at once, which is inherited by the script. I think it would be a good idea to try and keep requests to steam api low.
I suggest reducing the number of recent nodes to 70 – that leaves room for 30 favorites. If the user has more, the online state will just be less accurate.