### PR TITLE
Automatically attach to the dark souls process

### DIFF
--- a/DaS-PC-MPChan/DSCM.Designer.vb
+++ b/DaS-PC-MPChan/DSCM.Designer.vb
@@ -37,7 +37,6 @@ Partial Class DSCM
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(DSCM))
         Me.chkDebugDrawing = New System.Windows.Forms.CheckBox()
         Me.lblVer = New System.Windows.Forms.Label()
-        Me.btnReconnect = New System.Windows.Forms.Button()
         Me.chkExpand = New System.Windows.Forms.CheckBox()
         Me.dgvMPNodes = New System.Windows.Forms.DataGridView()
         Me.txtCurrNodes = New System.Windows.Forms.TextBox()
@@ -63,6 +62,7 @@ Partial Class DSCM
         Me.lblNewVersion = New System.Windows.Forms.Label()
         Me.lblUrl = New System.Windows.Forms.Label()
         Me.chkDSCMNet = New System.Windows.Forms.CheckBox()
+        Me.dsProcessStatus = New System.Windows.Forms.TextBox()
         CType(Me.dgvMPNodes,System.ComponentModel.ISupportInitialize).BeginInit
         CType(Me.nmbMaxNodes,System.ComponentModel.ISupportInitialize).BeginInit
         Me.tabs.SuspendLayout
@@ -97,15 +97,6 @@ Partial Class DSCM
         Me.lblVer.Size = New System.Drawing.Size(76, 13)
         Me.lblVer.TabIndex = 49
         Me.lblVer.Text = "2016.05.02.23"
-        '
-        'btnReconnect
-        '
-        Me.btnReconnect.Location = New System.Drawing.Point(1, 615)
-        Me.btnReconnect.Name = "btnReconnect"
-        Me.btnReconnect.Size = New System.Drawing.Size(69, 23)
-        Me.btnReconnect.TabIndex = 50
-        Me.btnReconnect.Text = "Reattach"
-        Me.btnReconnect.UseVisualStyleBackColor = true
         '
         'chkExpand
         '
@@ -470,11 +461,20 @@ Partial Class DSCM
         Me.chkDSCMNet.Text = "Join DSCM-Net"
         Me.chkDSCMNet.UseVisualStyleBackColor = false
         '
+        'dsProcessStatus
+        '
+        Me.dsProcessStatus.Location = New System.Drawing.Point(10, 617)
+        Me.dsProcessStatus.Name = "dsProcessStatus"
+        Me.dsProcessStatus.ReadOnly = true
+        Me.dsProcessStatus.Size = New System.Drawing.Size(187, 20)
+        Me.dsProcessStatus.TabIndex = 74
+        '
         'DSCM
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6!, 13!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(784, 642)
+        Me.Controls.Add(Me.dsProcessStatus)
         Me.Controls.Add(Me.chkDSCMNet)
         Me.Controls.Add(Me.lblUrl)
         Me.Controls.Add(Me.lblNewVersion)
@@ -491,7 +491,6 @@ Partial Class DSCM
         Me.Controls.Add(Me.lblNodes)
         Me.Controls.Add(Me.txtCurrNodes)
         Me.Controls.Add(Me.chkExpand)
-        Me.Controls.Add(Me.btnReconnect)
         Me.Controls.Add(Me.lblVer)
         Me.Controls.Add(Me.chkDebugDrawing)
         Me.Icon = CType(resources.GetObject("$this.Icon"),System.Drawing.Icon)
@@ -514,7 +513,6 @@ Partial Class DSCM
 End Sub
     Friend WithEvents chkDebugDrawing As System.Windows.Forms.CheckBox
     Friend WithEvents lblVer As Label
-    Friend WithEvents btnReconnect As Button
     Friend WithEvents chkExpand As CheckBox
     Friend WithEvents dgvMPNodes As DataGridView
     Friend WithEvents txtCurrNodes As TextBox
@@ -540,4 +538,5 @@ End Sub
     Friend WithEvents dgvDSCMNet As DataGridView
     Friend WithEvents chkDSCMNet As CheckBox
     Friend WithEvents txtIRCDebug As System.Windows.Forms.TextBox
+    Friend WithEvents dsProcessStatus As System.Windows.Forms.TextBox
 End Class

--- a/DaS-PC-MPChan/DSCM.vb
+++ b/DaS-PC-MPChan/DSCM.vb
@@ -392,11 +392,9 @@ Public Class DSCM
     End Sub
 
     Private Sub refMpData_Tick() Handles refMpData.Tick
-        If IsNothing(dsProcess)
-            Exit Sub
-        End If
-        refMpData.Interval = 10000
+        If IsNothing(dsProcess) Then Return
         dsProcess.UpdateNodes()
+        If dsProcess.SelfNode.SteamId Is Nothing Then Return
         Dim nodes As New Dictionary(Of String, DSNode)(dsProcess.ConnectedNodes)
         nodes.Add(dsProcess.SelfNode.SteamId, dsProcess.SelfNode)
         If _ircClient IsNot Nothing

--- a/DaS-PC-MPChan/DSCM.vb
+++ b/DaS-PC-MPChan/DSCM.vb
@@ -10,6 +10,7 @@ Public Class DSCM
     Private WithEvents refTimer As New System.Windows.Forms.Timer()
     Private WithEvents onlineTimer As New System.Windows.Forms.Timer()
     Private WithEvents ircConnectTimer As New System.Windows.Forms.Timer()
+    Private WithEvents dsProcessTimer As New System.Windows.Forms.Timer()
     Private WithEvents hotkeyTimer As New System.Windows.Forms.Timer()
 
     'For hotkey support
@@ -50,10 +51,10 @@ Public Class DSCM
 
         ircConnectTimer.Interval = 20000
 
-        Try
-            dsProcess = New DarkSoulsProcess()
-        Catch ex As DSProcessNotFound
-        End Try
+        dsProcessTimer.Interval = 1000
+        dsProcessTimer.Start()
+
+        attachDSProcess()
 
         'Set initial form size to non-expanded
         Me.Width = 450
@@ -354,7 +355,7 @@ Public Class DSCM
         dgvFavoriteNodes.Height = Me.Height - 225
         dgvRecentNodes.Height = Me.Height - 225
 
-        btnReconnect.Location = New Point(1, Me.Height - 65)
+        dsProcessStatus.Location = New Point(10, Me.Height - 63)
         lblVer.Location = New Point(Me.Width - 100, Me.Height - 55)
 
         lblNodes.Location = New Point(Me.Width - 167, 6)
@@ -371,16 +372,23 @@ Public Class DSCM
         btnRemFavorite.Location = New Point(400, Me.Height - 65)
     End Sub
 
-    Private Sub btnReconnect_Click(sender As Object, e As EventArgs) Handles btnReconnect.Click
-        If Not IsNothing(dsProcess) Then
-            dsProcess.Dispose()
-            dsProcess = Nothing
+    Private Sub attachDSProcess() Handles dsProcessTimer.Tick
+        If dsProcess isNot Nothing Then
+            If Not dsProcess.IsAttached
+                dsProcess.Dispose()
+                dsProcess = Nothing
+            End If
         End If
-        
-        Try
-            dsProcess = New DarkSoulsProcess()
-        Catch ex As DSProcessNotFound
-        End Try
+        If dsProcess is Nothing Then
+            Try
+                dsProcess = New DarkSoulsProcess()
+                dsProcessStatus.Text = " Attached to Dark Souls process"
+                dsProcessStatus.BackColor = System.Drawing.Color.FromArgb(200, 255, 200)
+            Catch ex As DSProcessAttachException
+                dsProcessStatus.Text = " " & ex.Message
+                dsProcessStatus.BackColor = System.Drawing.Color.FromArgb(255, 200, 200)
+            End Try
+        End If
     End Sub
 
     Private Sub chkDebugDrawing_CheckedChanged(sender As Object, e As EventArgs) Handles chkDebugDrawing.CheckedChanged


### PR DESCRIPTION
I usually start dscm before I start dark souls, which means I then have to alt-tab out of dark souls to click the reconnect button and then alt-tab back into dark souls.

This fixes that :).

