### PR TITLE
Create separate IRC message for self reporting

### DIFF
--- a/DaS-PC-MPChan/DSCM.vb
+++ b/DaS-PC-MPChan/DSCM.vb
@@ -415,19 +415,21 @@ Public Class DSCM
 
     Private Sub refMpData_Tick() Handles refMpData.Tick
         Dim nodes As Dictionary(Of String, DSNode)
+        Dim selfNode As DSNode = Nothing
         If dsProcess Is Nothing Then
             nodes = New Dictionary(Of String, DSNode)()
         Else
             dsProcess.UpdateNodes()
             If dsProcess.SelfNode.SteamId Is Nothing Then Return
             nodes = New Dictionary(Of String, DSNode)(dsProcess.ConnectedNodes)
-            nodes.Add(dsProcess.SelfNode.SteamId, dsProcess.SelfNode)
+            selfNode = dsProcess.SelfNode
         End If
 
         If _ircClient IsNot Nothing
-            _ircClient.setLocalNodes(nodes.Values)
+            _ircClient.setLocalNodes(selfNode, nodes.Values)
         End If
 
+        nodes.Add(dsProcess.SelfNode.SteamId, dsProcess.SelfNode)
         For Each node As DSNode In nodes.Values
             Dim row As DataGridViewRow = Nothing
             For j = 0 To dgvMPNodes.Rows.Count - 1

--- a/DaS-PC-MPChan/DSNode.vb
+++ b/DaS-PC-MPChan/DSNode.vb
@@ -68,7 +68,21 @@ Public Class DSNode
             Covenant = other.Covenant AndAlso
             Indictments = other.Indictments)
     End Function
-
+    Public Function BasicEquals(other As DSNode) As Boolean
+        If Object.ReferenceEquals(Me, other) Then Return True
+        Return (
+            SteamId = other.SteamId AndAlso
+            CharacterName = other.CharacterName AndAlso
+            SoulLevel = other.SoulLevel AndAlso
+            PhantomType = other.PhantomType AndAlso
+            MPZone = other.MPZone AndAlso
+            World = other.World)
+    End Function
+    Public ReadOnly Property HasExtendedInfo As Boolean
+        Get
+            Return Covenant <> -1
+        End Get
+    End Property
     Public ReadOnly Property SteamIdColumn As String
         Get
             Return SteamId


### PR DESCRIPTION
The parsing logic is still the same for both messages as this still works out, but this can be split in the future once it is necessary.