### PR TITLE
Improve IRC handling

### DIFF
--- a/DaS-PC-MPChan/DSCM.vb
+++ b/DaS-PC-MPChan/DSCM.vb
@@ -25,6 +25,7 @@ Public Class DSCM
     Dim oneHeld As Boolean
     Dim twoheld As Boolean
 
+    Public Version As String
     'New version of DSCM available?
     Dim newstablever As Boolean = False
     Dim newtestver As Boolean = False
@@ -39,6 +40,7 @@ Public Class DSCM
         chkDebugDrawing.Checked = False
     End Sub
     Private Sub DSCM_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        Version = lblVer.Text
         'Start Refresh timer
         refTimer.Interval = 200
         refTimer.Start()
@@ -255,8 +257,8 @@ Public Class DSCM
             Dim stablever = File.ReadAllLines(Path.GetTempPath & "\dscm-ver.txt")(0)
             Dim testver = File.ReadAllLines(Path.GetTempPath & "\dscm-ver.txt")(1)
 
-            newstablever = (stablever > lblVer.Text.Replace(".", ""))
-            newtestver = (testver > lblVer.Text.Replace(".", ""))
+            newstablever = (stablever > Version.Replace(".", ""))
+            newtestver = (testver > Version.Replace(".", ""))
         Catch ex As Exception
             'Fail silently since nobody wants to be bothered for an update check.
         End Try

--- a/DaS-PC-MPChan/IRCClient.vb
+++ b/DaS-PC-MPChan/IRCClient.vb
@@ -176,7 +176,7 @@ Public Class IRCClient
                 Catch ex As Exception
 #If DEBUG Then
                     Dim senderNick As String = Regex.Match(prefix, "^([^!@]+)").Groups.Item(1).Value
-                    setStatus("Parsing: " & senderNick & " " & line.Split({" "c}, 4)(3).Substring(1))
+                    setStatus("Invalid: " & senderNick & "   " & msg)
 #End If
                     Return
                 End Try

--- a/DaS-PC-MPChan/IRCClient.vb
+++ b/DaS-PC-MPChan/IRCClient.vb
@@ -96,7 +96,7 @@ Public Class IRCClient
     End Sub
 
     Private Sub connectToServer()
-        Dim nick As String = "DSCM-" & Guid.NewGuid.ToString()
+        Dim nick As String = "DSCM[" & mainWindow.Version.Replace(".", "-") & "]" & Guid.NewGuid.ToString().Split("-")(0)
         Dim owner As String = "DSCMbot"
         Dim server As String = "dscm.wulf2k.ca"
         Dim port As Integer = 8123

--- a/DaS-PC-MPChan/IRCClient.vb
+++ b/DaS-PC-MPChan/IRCClient.vb
@@ -3,10 +3,20 @@ Imports System.IO
 Imports System.Net.Sockets
 Imports System.Collections.Concurrent
 
+Class IRCConnectionError
+    Inherits System.ApplicationException
+
+    Sub New(message As String)
+        MyBase.New(message)
+    End Sub
+End Class
+
 Public Class IRCClient
     Private mainWindow As DSCM
 
     Private _thread As Thread
+    Private tcpClient As System.Net.Sockets.TcpClient
+    Private stream As NetworkStream
     Private _streamWriter As StreamWriter = Nothing
     Private _streamReader As StreamReader = Nothing
 
@@ -61,65 +71,22 @@ Public Class IRCClient
     End Function
 
     Private Sub main(args As String())
-        Dim port As Integer
-        Dim buf As String, nick As String, owner As String, server As String, chan As String
-        Dim tcpClient As New System.Net.Sockets.TcpClient()
-        Dim stream As NetworkStream
-
-
         Try
-            nick = "DSCM-" & Guid.NewGuid.ToString()
-            owner = "DSCMbot"
-            server = "dscm.wulf2k.ca"
-            port = 8123
-            chan = "#DSCM-Main"
-
-            setStatus("Initiating connection")
-            'Connect to irc server and get input and output text streams from TcpClient.
-            tcpClient.Connect(server, port)
-            If Not tcpClient.Connected Then
-                setStatus("Failed to connect.")
-                Return
-            End If
-            stream = tcpClient.GetStream()
-            _streamReader = New StreamReader(stream)
-            _streamWriter = New StreamWriter(stream)
-            _streamWriter.AutoFlush = True
-
-            _streamWriter.Write("USER " & nick & " 0 * :" & owner & vbCr & vbLf)
-            _streamWriter.Write("NICK " & nick & vbCr & vbLf)
-            _streamWriter.Write("MODE " & nick & " +B" & vbCr & vbLf)
-
-            'Join channel on start
-            While True
-                buf = _streamReader.ReadLine()
-                If buf IsNot Nothing Then
-                    If buf.StartsWith("PING ") Then
-                        _streamWriter.Write(buf.Replace("PING", "PONG") & vbCr & vbLf)
+            While Not shouldQuit
+                Try
+                    setStatus("Initiating connection ...")
+                    connectToServer()
+                    setStatus("Connected.")
+                    messageLoop()
+                Catch ex As IRCConnectionError
+                    If Not shouldQuit Then
+                        setStatus("Error: " & ex.Message & " – retrying in 10 seconds")
+                        Thread.Sleep(10000)
                     End If
-
-                    If buf.Contains(":MOTD") Then
-                        _streamWriter.Write("JOIN " & chan & vbCr & vbLf)
-                        Exit While
-                    End If
-                End If
-            End While
-
-            setStatus("Connected.")
-
-            Dim lastPublish As Date = DateTime.UtcNow
-            While True
-                If shouldQuit Then
-                    _streamWriter.Write("QUIT" & vbCr & vbLf)
-                    Exit While
-                ElseIf (DateTime.UtcNow - lastPublish).TotalSeconds >= 120 Then
-                    lastPublish = DateTime.UtcNow
-                    publishLocalNodes()
-                    expireIrcNodes()
-                ElseIf stream.DataAvailable Then
-                    handleIRCLine(_streamReader.ReadLine())
-                Else
-                    Thread.Sleep(50)
+                End Try
+                If tcpClient IsNot Nothing Then
+                    tcpClient.Close()
+                    tcpClient = Nothing
                 End If
             End While
             setStatus("Disconnected.")
@@ -128,14 +95,69 @@ Public Class IRCClient
         End Try
     End Sub
 
+    Private Sub connectToServer()
+        Dim nick As String = "DSCM-" & Guid.NewGuid.ToString()
+        Dim owner As String = "DSCMbot"
+        Dim server As String = "dscm.wulf2k.ca"
+        Dim port As Integer = 8123
+        Dim chan As String = "#DSCM-Main"
+
+        tcpClient = New System.Net.Sockets.TcpClient()
+        tcpClient.Connect(server, port)
+        If Not tcpClient.Connected Then
+            Throw New IRCConnectionError("Failed to connect")
+        End If
+        stream = tcpClient.GetStream()
+        _streamReader = New StreamReader(stream)
+        _streamWriter = New StreamWriter(stream)
+        _streamWriter.AutoFlush = True
+
+        _streamWriter.Write("USER " & nick & " 0 * :" & owner & vbCr & vbLf)
+        _streamWriter.Write("NICK " & nick & vbCr & vbLf)
+        _streamWriter.Write("MODE " & nick & " +B" & vbCr & vbLf)
+
+        'Join channel on start
+        While True
+            If isConnectionDropped() Then
+                Throw New IRCConnectionError("Connection was dropped during init")
+            End If
+            Dim buf As String = _streamReader.ReadLine()
+            If buf IsNot Nothing Then
+                If buf.StartsWith("PING ") Then
+                    _streamWriter.Write(buf.Replace("PING", "PONG") & vbCr & vbLf)
+                Else If buf.Contains(":MOTD") Then
+                    _streamWriter.Write("JOIN " & chan & vbCr & vbLf)
+                    Exit While
+                End If
+            End If
+        End While
+    End Sub
+    Private Sub messageLoop()
+        Dim lastPublish As Date = DateTime.UtcNow
+        While True
+            If shouldQuit Then
+                _streamWriter.Write("QUIT" & vbCr & vbLf)
+                Exit While
+            ElseIf isConnectionDropped() Then
+                Throw New IRCConnectionError("Connection was dropped")
+            ElseIf (DateTime.UtcNow - lastPublish).TotalSeconds >= 120 Then
+                lastPublish = DateTime.UtcNow
+                publishLocalNodes()
+                expireIrcNodes()
+            ElseIf stream.DataAvailable Then
+                handleIRCLine(_streamReader.ReadLine())
+            Else
+                Thread.Sleep(50)
+            End If
+        End While
+    End Sub
+    Private Function isConnectionDropped() As Boolean
+        Return tcpClient.Client.Poll(0, SelectMode.SelectRead) AndAlso tcpClient.Client.Available = 0
+    End Function
     Private Sub handleIRCLine(line As String)
-        'Send pong reply to any ping messages
         If line.StartsWith("PING ") Then
             _streamWriter.Write(line.Replace("PING", "PONG") & vbCr & vbLf)
-        End If
-
-        'Parse report commands
-        If line.Contains("REPORT|") Or line.Contains("REPORTSELF|") Then
+        Else If line.Contains("REPORT|") Or line.Contains("REPORTSELF|") Then
             Try
                 Dim inNode As DSNode
                 inNode = parseNodeReport(line.Split("|")(1))

--- a/DaS-PC-MPChan/IRCClient.vb
+++ b/DaS-PC-MPChan/IRCClient.vb
@@ -162,24 +162,22 @@ Public Class IRCClient
             Dim senderNick As String = Nothing
             Dim m As Match = Regex.Match(line, "^:([^!]+)!")
             If m.Success Then senderNick = m.Groups.Item(1).Value
+            Dim inNode As DSNode
             Try
-                Dim inNode As DSNode
                 inNode = parseNodeReport(line.Split("|")(1))
-                If (ircNodes.ContainsKey(inNode.SteamId) AndAlso
-                        Not inNode.HasExtendedInfo AndAlso
-                        ircNodes(inNode.SteamId).Item1.HasExtendedInfo) Then
-                    inNode.Covenant = ircNodes(inNode.SteamId).Item1.Covenant
-                    inNode.Indictments = ircNodes(inNode.SteamId).Item1.Indictments
-                End If
-                ircNodes(inNode.SteamId) = Tuple.Create(inNode, DateTime.UtcNow)
             Catch ex As Exception
-                ' Silence errors from old version that is known to be buggy
-                ' first implementation of IRC
-                Dim firstVersion = Regex.IsMatch(senderNick, "^DSCM-[0-1a-f]{16}$")
-                If Not firstVersion Then
-                    setStatus("Error processing player report - " & ex.Message)
-                End If
+#If DEBUG Then
+                setStatus("Parsing: " & senderNick & " " & line.Split({" "c}, 4)(3).Substring(1))
+#End If
+                Return
             End Try
+            If (ircNodes.ContainsKey(inNode.SteamId) AndAlso
+                    Not inNode.HasExtendedInfo AndAlso
+                    ircNodes(inNode.SteamId).Item1.HasExtendedInfo) Then
+                inNode.Covenant = ircNodes(inNode.SteamId).Item1.Covenant
+                inNode.Indictments = ircNodes(inNode.SteamId).Item1.Indictments
+            End If
+            ircNodes(inNode.SteamId) = Tuple.Create(inNode, DateTime.UtcNow)
         End If
     End Sub
 

--- a/DaS-PC-MPChan/My Project/AssemblyInfo.vb
+++ b/DaS-PC-MPChan/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.0.0.0")> 
-<Assembly: AssemblyFileVersion("1.0.0.0")> 
+<Assembly: AssemblyVersion("1.0.*")> 
+'<Assembly: AssemblyFileVersion("1.0.0.0")> 


### PR DESCRIPTION
See commit list for features.

I think we should try and get out a stable version soon. I'd say merge this and the help PR and release a testversion, and if no bugs are reported within a few days, release it as stable.

Then aggressively spread the news and see how big DSCM-Net can actually be. That would give us a ways better information base to implement smarter matchmaking.

The only feature that I can think of that would be really useful before a release is an autoupdater. Otherwise we will always have old versions hanging out in IRC. But implementing an autoupdater correctly seems a lot of work, and I guess having the version number in the IRC nick should be good enough for the start?