### PR TITLE
Prevent selfNode from counting as connected

### DIFF
--- a/DaS-PC-MPChan/DarkSoulsProcess.vb
+++ b/DaS-PC-MPChan/DarkSoulsProcess.vb
@@ -384,10 +384,11 @@ Public Class DarkSoulsProcess
             Dim steamData2 As Integer = ReadInt32(steamData1 + &HC)
             node.SteamId = ReadSteamIdUnicode(steamData2 + &H30)
             node.CharacterName = ReadSteamName(steamData1 + &H30)
-            basicNodeInfo(node.SteamId) = node.CharacterName
             If node.SteamId = SelfSteamId Then
                 SelfNode.SteamId = node.SteamId
                 SelfNode.CharacterName = node.CharacterName
+            Else
+                basicNodeInfo(node.SteamId) = node.CharacterName
             End If
             steamNodesPtr = ReadInt32(steamNodesPtr)
         Next


### PR DESCRIPTION
This should fix #44, but is really weird. Apparently the client's own node was part of the nodedump, which is usually not the case.