### PR TITLE
Enable max node input only while it's actually doing something

### DIFF
--- a/DaS-PC-MPChan/DSCM.Designer.vb
+++ b/DaS-PC-MPChan/DSCM.Designer.vb
@@ -180,6 +180,7 @@ Partial Class DSCM
         '
         'nmbMaxNodes
         '
+        Me.nmbMaxNodes.Enabled = false
         Me.nmbMaxNodes.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.nmbMaxNodes.Location = New System.Drawing.Point(737, 3)
         Me.nmbMaxNodes.Maximum = New Decimal(New Integer() {32, 0, 0, 0})

--- a/DaS-PC-MPChan/DSCM.vb
+++ b/DaS-PC-MPChan/DSCM.vb
@@ -422,10 +422,16 @@ Public Class DSCM
             End If
         End If
         If dsProcess is Nothing Then
+            nmbMaxNodes.Enabled = False
             Try
                 dsProcess = New DarkSoulsProcess()
                 dsProcessStatus.Text = " Attached to Dark Souls process"
                 dsProcessStatus.BackColor = System.Drawing.Color.FromArgb(200, 255, 200)
+
+                'PVP Watchdog overrides any node count changes we make
+                If Not dsProcess.HasWatchdog Then
+                    nmbMaxNodes.Enabled = True
+                End If
             Catch ex As DSProcessAttachException
                 dsProcessStatus.Text = " " & ex.Message
                 dsProcessStatus.BackColor = System.Drawing.Color.FromArgb(255, 200, 200)

--- a/DaS-PC-MPChan/DarkSoulsProcess.vb
+++ b/DaS-PC-MPChan/DarkSoulsProcess.vb
@@ -41,19 +41,19 @@ Public Class DarkSoulsProcess
     Private _targetProcessHandle As IntPtr = IntPtr.Zero
 
     'Addresses of the various inserted functions
-    Dim namedNodePtr As IntPtr = 0
-    Dim nodeDumpPtr As IntPtr = 0
-    Dim attemptIdPtr As IntPtr = 0
+    Private namedNodePtr As IntPtr = 0
+    Private nodeDumpPtr As IntPtr = 0
+    Private attemptIdPtr As IntPtr = 0
 
     'Dark Souls
-    Dim dsBase As IntPtr = 0
+    Private dsBase As IntPtr = 0
     'Steam API
-    Dim steamApiBase As IntPtr = 0
+    Private steamApiBase As IntPtr = 0
     'PVP Watchdog
-    Dim watchdogBase As IntPtr = 0
+    Private watchdogBase As IntPtr = 0
 
 
-    Dim steamApiDllModule As ProcessModule
+    Private steamApiDllModule As ProcessModule
 
     Public ConnectedNodes As New Dictionary(Of String, DSNode)()
     Public SelfNode As New DSNode()
@@ -119,12 +119,8 @@ Public Class DarkSoulsProcess
                     dsBase = dll.BaseAddress
 
                 Case "d3d9.dll"
-                    watchdogBase = dll.BaseAddress
-
-                    If ReadUInt8(watchdogBase + &H6E41) <> &HE8& Then
-                        watchdogBase = 0
-                        'this is ineffective at disabling PVP Watchdog's node write
-                        'WriteBytes(watchdogBase + &H6E41, {&H90, &H90, &H90, &H90, &H90})
+                    If dll.FileVersionInfo.ProductName.Contains("Watchdog") Then
+                        watchdogBase = dll.BaseAddress
                     End If
 
                 Case "steam_api.dll" 'Find steam_api.dll for ability to directly add SteamIDs as nodes
@@ -152,6 +148,11 @@ Public Class DarkSoulsProcess
     Public ReadOnly Property IsAttached As Boolean
         Get
             Return Not _targetProcess.HasExited
+        End Get
+    End Property
+    Public ReadOnly Property HasWatchdog As Boolean
+        Get
+            Return watchdogBase <> 0
         End Get
     End Property
     Public Property DrawNodes As Boolean


### PR DESCRIPTION
Changes to that setting while DS is not running will be overwritten when DS is started.
All changes are always overwritten if PVP Watchdog is active.

Signal these things to the user by disabling the input.