### PR TITLE
Improve DSCM-Net list display (fixes #45)

### DIFF
--- a/DaS-PC-MPChan/DSCM.vb
+++ b/DaS-PC-MPChan/DSCM.vb
@@ -2,6 +2,7 @@
 Imports System.IO
 Imports System.Text.RegularExpressions
 Imports System.Net.Sockets
+Imports System.ComponentModel
 
 
 Public Class DSCM
@@ -32,8 +33,8 @@ Public Class DSCM
 
     Private dsProcess As DarkSoulsProcess = Nothing
     Private _ircClient As IRCClient = Nothing
-    Private ircDisplayList As New SortableBindingList(Of DSNode)(New List(Of DSNode))
-    
+    Private ircDisplayList As New SortableBindingList(Of DSNode)()
+
     Private recentConnections As New Queue(Of Tuple(Of Date, String))
 
     Private Sub DSCM_Close(sender As Object, e As EventArgs) Handles MyBase.FormClosed
@@ -85,6 +86,7 @@ Public Class DSCM
             .Columns(5).ValueType = GetType(String)
             .Font = New Font("Consolas", 10)
             .AlternatingRowsDefaultCellStyle.BackColor = AlternateRowColor
+            .SelectionMode = DataGridViewSelectionMode.FullRowSelect
         End With
 
         With dgvFavoriteNodes
@@ -99,6 +101,7 @@ Public Class DSCM
             .Columns(2).ValueType = GetType(String)
             .Font = New Font("Consolas", 10)
             .AlternatingRowsDefaultCellStyle.BackColor = AlternateRowColor
+            .SelectionMode = DataGridViewSelectionMode.FullRowSelect
         End With
 
         With dgvRecentNodes
@@ -116,6 +119,7 @@ Public Class DSCM
             .Columns(3).ValueType = GetType(String)
             .Font = New Font("Consolas", 10)
             .AlternatingRowsDefaultCellStyle.BackColor = AlternateRowColor
+            .SelectionMode = DataGridViewSelectionMode.FullRowSelect
         End With
 
         With dgvDSCMNet
@@ -131,6 +135,7 @@ Public Class DSCM
             .Columns.Add("soulLevel", "SL")
             .Columns("soulLevel").Width = 40
             .Columns("soulLevel").DataPropertyName = "SoulLevelColumn"
+            .Columns("soulLevel").DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight
             .Columns.Add("phantomType", "Phantom Type")
             .Columns("phantomType").Width = 70
             .Columns("phantomType").DataPropertyName = "PhantomTypeText"
@@ -146,8 +151,11 @@ Public Class DSCM
             .Columns.Add("indictments", "Sin")
             .Columns("indictments").Width = 60
             .Columns("indictments").DataPropertyName = "IndictmentsColumn"
+            .Columns("indictments").DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight
             .Font = New Font("Consolas", 10)
-            .AlternatingRowsDefaultCellStyle.BackColor = AlternateRowColor
+            .SelectionMode = DataGridViewSelectionMode.FullRowSelect
+            .Sort(.Columns("steamId"), ListSortDirection.Ascending)
+            .Sort(.Columns("soulLevel"), ListSortDirection.Descending)
         End With
 
 
@@ -348,33 +356,43 @@ Public Class DSCM
             txtCurrNodes.Text = dsProcess.NodeCount
         End If
 
-        ' Sync IRC Nodes from client to display list
+        updateIrcInfo()
+    End Sub
+    Private Sub updateIrcInfo()
         If _ircClient IsNot Nothing Then
+            Dim firstDisplayRow = dgvDSCMNet.FirstDisplayedScrollingRowIndex
             Dim seenNodes As New HashSet(Of String)
             For i = ircDisplayList.Count - 1 To 0 Step -1
                 Dim node As DSNode = ircDisplayList(i)
                 If Not _ircClient.ircNodes.ContainsKey(node.SteamId) Then
                     ircDisplayList.RemoveAt(i)
+                    If i < firstDisplayRow Then firstDisplayRow -= 1
                 Else
                     seenNodes.Add(node.SteamId)
                     Dim ircNode As DSNode = _ircClient.ircNodes(node.SteamId).Item1
                     If Not node.MemberwiseEquals(ircNode) Then
-                        ircDisplayList(i) = ircNode
+                        ircDisplayList.ReplaceSorted(i, ircNode)
                     End If
                 End If
             Next
             For Each t In _ircClient.ircNodes.Values
                 If Not seenNodes.Contains(t.Item1.SteamId) Then
-                    ircDisplayList.Add(t.Item1)
+                    Dim index = ircDisplayList.InsertSorted(t.Item1)
+                    If index < firstDisplayRow Then firstDisplayRow += 1
                 End If
             Next
+            If firstDisplayRow >= 0 And firstDisplayRow < ircDisplayList.Count Then
+                dgvDSCMNet.FirstDisplayedScrollingRowIndex = firstDisplayRow
+            Else
+                Dim x =  6
+            End If
         End If
 
-        If chkDSCMNet.Checked and Not tabDSCMNet.Text = "DSCM-Net (" & dgvDSCMNet.Rows.Count & ")" Then
+        If Not tabDSCMNet.Text = "DSCM-Net (" & dgvDSCMNet.Rows.Count & ")" Then
             tabDSCMNet.Text = "DSCM-Net (" & dgvDSCMNet.Rows.Count & ")"
         End If
     End Sub
-    Private Shared Sub hotkeyTimer_Tick() Handles hotkeytimer.Tick
+    Private Shared Sub hotkeyTimer_Tick() Handles hotkeyTimer.Tick
         Dim ctrlkey As Boolean
         Dim oneKey As Boolean 'Toggle Node Display
         Dim twoKey As Boolean 'Previously toggled NamedNodes, now a free hotkey.

--- a/DaS-PC-MPChan/DSNode.vb
+++ b/DaS-PC-MPChan/DSNode.vb
@@ -93,14 +93,24 @@ Public Class DSNode
             Return CharacterName
         End Get
     End Property
-    Public ReadOnly Property SoulLevelColumn As Integer
+    Public ReadOnly Property SoulLevelColumn As String
+        Get
+            Return If(SoulLevel >= 0, SoulLevel, "")
+        End Get
+    End Property
+    Public ReadOnly Property SoulLevelColumnSort As Integer
         Get
             Return SoulLevel
         End Get
     End Property
-    Public ReadOnly Property MPZoneColumn As Integer
+    Public ReadOnly Property MPZoneColumn As String
         Get
-            Return MPZone
+            Return If(MPZone <= 0, "", MPZone)
+        End Get
+    End Property
+    Public ReadOnly Property MPZoneColumnSort As Integer
+        Get
+            Return If(MPZone <= 0, 0, MPZone)
         End Get
     End Property
     Public ReadOnly Property PhantomTypeText As String
@@ -139,7 +149,11 @@ Public Class DSNode
             End If
         End Get
     End Property
-
+    Public ReadOnly Property IndictmentsColumnSort As Integer
+        Get
+            Return Indictments
+        End Get
+    End Property
 
     Public Function canCoop(other As DSNode) As Boolean
         Return Math.Abs(SoulLevel - other.SoulLevel) <= (10 + SoulLevel * 0.1)

--- a/DaS-PC-MPChan/SortableBindingList.vb
+++ b/DaS-PC-MPChan/SortableBindingList.vb
@@ -3,219 +3,87 @@ Imports System.ComponentModel
 Imports System.Reflection
 Imports System.Linq
 
-''' <summary>
-''' SortableBindingList is a list that supports sorting its items and filtering them.
-''' When binding a <see cref="System.Collections.Generic.List(Of T)"/> to a <see cref="System.Windows.Forms.DataGridView"/>, you can not sort by clicking on the columns
-''' or filter the list. With this list, you can.
-''' 
-''' Dependencies:
-'''  - .NET 3.5 or higher
-'''  - System.Linq.Dynamic (DynamicQuery NuGet package: http://www.nuget.org/packages/DynamicQuery/)
-''' </summary>
-''' <typeparam name="T">The data type represented by this SortableBindingList</typeparam>
-''' <remarks></remarks>
+Class SortComparer(Of T)
+    Implements IComparer(Of T)
+    Private _sorts As IEnumerable(Of ListSortDescription)
+    Public Sub New(sorts As IEnumerable(Of ListSortDescription))
+        _sorts = sorts
+    End Sub
+    Public Function Compare(x As T, y As T) As Integer Implements IComparer(Of T).Compare
+        For Each sort In _sorts
+            Dim prop As PropertyDescriptor = sort.PropertyDescriptor
+            Dim sortProp = TypeDescriptor.GetProperties(GetType(T)).Find(prop.Name + "Sort", True)
+            prop = If(sortProp, prop)
+            Dim cmp = DirectCast(prop.GetValue(x), IComparable).CompareTo(prop.GetValue(y))
+            If cmp <> 0 Then
+                If sort.SortDirection = ListSortDirection.Descending Then
+                    cmp *= -1
+                End If
+                Return cmp
+            End If
+        Next
+        Return 0
+    End Function
+End Class
+
 Public Class SortableBindingList(Of T)
     Inherits BindingList(Of T)
-    Implements IBindingListView
 
+    Private _listSortDescriptors As New List(Of ListSortDescription)
 
-    Private _isSorted As Boolean = False
-    Private _listSortDescriptors As IEnumerable(Of ListSortDescription)
-    Private ReadOnly _originalData As List(Of T)
-
-    ''' <summary>
-    ''' Creates a new instance of SortableBindingList and populates it with the contents of the given list.
-    ''' </summary>
-    ''' <param name="list"></param>
-    ''' <remarks></remarks>
-    Public Sub New(list As IEnumerable(Of T))
-        MyBase.New(list.ToList()) 'BindingList(Of T) requires an IList(Of T)
-
-        _originalData = New List(Of T)(list)
+    Public Sub ReplaceSorted(oldIndex As Integer, item As T)
+        Me.Items.RemoveAt(oldIndex)
+        
+        Dim comparer As New SortComparer(Of T)(_listSortDescriptors)
+        Dim index = Items.ToList().BinarySearch(item, comparer)
+        If index < 0 Then
+            index = index Xor -1
+        End If
+        Me.Items.Insert(index, item)
+        Me.OnListChanged(New ListChangedEventArgs(ListChangedType.ItemMoved, index, oldIndex))
     End Sub
 
-    Public Sub AddRange(collection As IEnumerable(Of T))
-        For Each tItem In collection
-            Items.Add(tItem)
-        Next
-
-        _originalData.AddRange(collection)
-    End Sub
+    Public Function InsertSorted(item As T) As Integer
+        Dim comparer As New SortComparer(Of T)(_listSortDescriptors)
+        Dim index = Items.ToList().BinarySearch(item, comparer)
+        If index < 0 Then
+            index = index Xor -1
+        End If
+        Me.InsertItem(index, item)
+        Return index
+    End Function
 
     Protected Overrides Sub ApplySortCore(ByVal prop As PropertyDescriptor, ByVal direction As ListSortDirection)
-        ' Check to see if the property type we are sorting by implements the IComparable interface.
-        Dim interfaceType As Type = prop.PropertyType.GetInterface("IComparable")
-
-        If interfaceType Is Nothing Then
-            'Check if this is a Nullable(Of IComparable)
-            If prop.PropertyType.IsGenericType AndAlso prop.PropertyType.GetGenericTypeDefinition() Is GetType(Nullable(Of )) Then
-                'Check if the type parameter implements IComparable
-                Dim tType As Type = prop.PropertyType.GetGenericArguments()(0)
-                interfaceType = tType.GetInterface("IComparable")
+        Dim newSort As New List(Of ListSortDescription)()
+        newSort.Add(New ListSortDescription(prop, direction))
+        For Each sortDesc As ListSortDescription In _listSortDescriptors
+            If sortDesc.PropertyDescriptor.Name <> prop.Name Then
+                newSort.Add(sortDesc)
             End If
-        End If
-
-        If interfaceType IsNot Nothing Then
-            'If so, set the SortPropertyValue and SortDirectionValue.
-            _listSortDescriptors = New List(Of ListSortDescription)({ _
-                New ListSortDescription(prop, direction) _
-            })
-
-            'Sort the list using LINQ (OrderBy).
-            Dim tempList = Items
-            If direction = ListSortDirection.Ascending Then
-                tempList = tempList.OrderBy(Function(x) prop.GetValue(x)).ToList()
-            Else
-                tempList = tempList.OrderByDescending(Function(x) prop.GetValue(x)).ToList()
-            End If
-
-            'Copy the sorted items back into the list.
-            Items.Clear()
-            For Each tItem In tempList
-                Items.Add(tItem)
-            Next
-
-            _isSorted = True
-
-            'Raise the ListChanged event so bound controls refresh their values.
-            OnListChanged(New ListChangedEventArgs(ListChangedType.Reset, -1))
-        Else
-            'If the property type does not implement IComparable, let the user know.
-            Throw New NotSupportedException(String.Format("Cannot sort by {0}. {1} does not implement IComparable.", prop.Name, _
-                prop.PropertyType.ToString()))
-        End If
+        Next
+        ApplySortCore(newSort)
     End Sub
 
-    Protected Overloads Sub ApplySortCore(ByVal sorts As IEnumerable(Of ListSortDescription), Optional ByVal informListeners As Boolean = True)
-        Try
-            Dim orderedList As IOrderedEnumerable(Of T) = Nothing
-            Dim bFirstOrder As Boolean = True
-            For Each sortDescriptor As ListSortDescription In sorts
-                Dim prop As PropertyDescriptor = sortDescriptor.PropertyDescriptor
-                Dim interfaceType As Type = prop.PropertyType.GetInterface("IComparable")
+    Protected Overloads Sub ApplySortCore(sorts As IEnumerable(Of ListSortDescription), Optional informListeners As Boolean = True)
+        Dim comparer As New SortComparer(Of T)(sorts)
+        Dim orderedList As IOrderedEnumerable(Of T) = Items.OrderBy(Function(x) x, comparer)
+        Dim result = orderedList.ToList()
 
-                If interfaceType Is Nothing Then
-                    'Check if this is a Nullable(Of IComparable)
-                    If prop.PropertyType.IsGenericType AndAlso prop.PropertyType.GetGenericTypeDefinition() Is GetType(Nullable(Of )) Then
-                        'Check if the type parameter implements IComparable
-                        Dim tType As Type = prop.PropertyType.GetGenericArguments()(0)
-                        interfaceType = tType.GetInterface("IComparable")
-                    End If
-                End If
-
-                If interfaceType Is Nothing Then
-                    'If the property type does not implement IComparable, let the user know.
-                    Throw New NotSupportedException(String.Format("Cannot sort by {0}. {1} does not implement IComparable.", prop.Name, _
-                        prop.PropertyType.ToString()))
-                End If
-
-                'Sort the list using LINQ (OrderBy/ThenBy). Remember if the sort operation is the first sort or not (OrderBy vs ThenBy).
-                If bFirstOrder Then
-                    bFirstOrder = False
-                    If sortDescriptor.SortDirection = ListSortDirection.Ascending Then
-                        orderedList = Items.OrderBy(Function(x) prop.GetValue(x))
-                    Else
-                        orderedList = Items.OrderByDescending(Function(x) prop.GetValue(x))
-                    End If
-                Else
-                    If sortDescriptor.SortDirection = ListSortDirection.Ascending Then
-                        orderedList = orderedList.ThenBy(Function(x) prop.GetValue(x))
-                    Else
-                        orderedList = orderedList.ThenByDescending(Function(x) prop.GetValue(x))
-                    End If
-                End If
-            Next
-
-            'Sorting succeeded
-            Dim result = orderedList.ToList()
-
-            'Copy the sorted items back into the list.
-            Items.Clear()
-            For Each tItem In result
-                Items.Add(tItem)
-            Next
-
-            _isSorted = True
-            _listSortDescriptors = sorts
-
-            'Most of the times, informListeners will be true. In rare cases, this function is called from EndNew, and then the OnListChanged event should not be fired.
-            If informListeners Then
-                'Raise the ListChanged event so bound controls refresh their values.
-                OnListChanged(New ListChangedEventArgs(ListChangedType.Reset, -1))
-            End If
-        Catch
-            'Reset the list
-            Items.Clear()
-            For Each tItem As T In _originalData
-                Items.Add(tItem)
-            Next
-
-            'Rethrow the error
-            Throw
-        End Try
-    End Sub
-
-    Protected Overrides Sub RemoveSortCore()
-        If Not _isSorted Then Return
-
-        'Restore original order
+        'Copy the sorted items back into the list.
         Items.Clear()
-        For Each tItem As T In _originalData
+        For Each tItem In result
             Items.Add(tItem)
         Next
-        _isSorted = False
-        OnListChanged(New ListChangedEventArgs(ListChangedType.Reset, -1))
-    End Sub
 
-    Public Sub RemoveSort()
-        RemoveSortCore()
-    End Sub
+        _listSortDescriptors = sorts
 
-    Public Function Find(Of TKey)(ByVal [property] As String, ByVal key As TKey) As Integer
-        ' Check the properties for a property with the specified name.
-        Dim properties As PropertyDescriptorCollection = TypeDescriptor.GetProperties(GetType(T))
-        Dim prop As PropertyDescriptor = properties.Find([property], True)
-
-        ' If there is not a match, return -1 otherwise pass search to FindCore method.
-        If prop Is Nothing Then Return -1
-        Return FindCore(prop, key)
-    End Function
-
-    Protected Overrides Function FindCore(ByVal prop As PropertyDescriptor, ByVal key As Object) As Integer
-        'Get the property info for the specified property.
-        Dim propInfo As PropertyInfo = GetType(T).GetProperty(prop.Name)
-        Dim tItem As T
-
-        If key IsNot Nothing Then
-            'Loop through the items to see if the key
-            ' value matches the property value.
-            For i As Integer = 0 To Count - 1
-                tItem = Items(i)
-                If (propInfo.GetValue(tItem, Nothing).Equals(key)) Then Return i
-            Next
+        'Most of the times, informListeners will be true. In rare cases, this function is called from EndNew, and then the OnListChanged event should not be fired.
+        If informListeners Then
+            'Raise the ListChanged event so bound controls refresh their values.
+            OnListChanged(New ListChangedEventArgs(ListChangedType.Reset, -1))
         End If
-
-        Return -1
-    End Function
-
-    Public Overrides Sub EndNew(itemIndex As Integer)
-        Try
-            'Check to see if the item is added to the end of the list,
-            'and if so, re-sort the list.
-            If _isSorted And itemIndex = Count - 1 Then
-                'Reapply the sort, but do not inform listeners, because this would reset the position.
-                ApplySortCore(_listSortDescriptors, False)
-            End If
-        Finally
-            MyBase.EndNew(itemIndex)
-        End Try
     End Sub
 
-    Protected Overrides ReadOnly Property SupportsSearchingCore() As Boolean
-        Get
-            Return True
-        End Get
-    End Property
 
     Protected Overrides ReadOnly Property SupportsSortingCore() As Boolean
         Get
@@ -225,7 +93,7 @@ Public Class SortableBindingList(Of T)
 
     Protected Overrides ReadOnly Property IsSortedCore() As Boolean
         Get
-            Return _isSorted
+            Return True
         End Get
     End Property
 
@@ -242,38 +110,4 @@ Public Class SortableBindingList(Of T)
             Return _listSortDescriptors(0).SortDirection
         End Get
     End Property
-
-    Public Property Filter() As String Implements IBindingListView.Filter
-        Get
-            Return Nothing
-        End Get
-        Set(value As String)
-        End Set
-    End Property
-
-    Public ReadOnly Property SortDescriptions() As ListSortDescriptionCollection Implements IBindingListView.SortDescriptions
-        Get
-            Return New ListSortDescriptionCollection(_listSortDescriptors.ToArray())
-        End Get
-    End Property
-
-    Public ReadOnly Property SupportsAdvancedSorting() As Boolean Implements IBindingListView.SupportsAdvancedSorting
-        Get
-            Return True
-        End Get
-    End Property
-
-    Public ReadOnly Property SupportsFiltering() As Boolean Implements IBindingListView.SupportsFiltering
-        Get
-            Return False
-        End Get
-    End Property
-
-    Public Sub ApplySort(ByVal sorts As ListSortDescriptionCollection) Implements IBindingListView.ApplySort
-        ApplySortCore(sorts.Cast(Of ListSortDescription)())
-    End Sub
-
-    Public Sub RemoveFilter() Implements IBindingListView.RemoveFilter
-
-    End Sub
 End Class


### PR DESCRIPTION
* Sorting is now remembered and applied to new nodes
* "N/A" values are displayed as empty cells
* Numeric columns are displayed and sorted correctly