### PR TITLE
unblock onlinecheck

### DIFF
--- a/DaS-PC-MPChan/DSCM.vb
+++ b/DaS-PC-MPChan/DSCM.vb
@@ -18,10 +18,6 @@ Public Class DSCM
     'For hotkey support
     Public Declare Function GetAsyncKeyState Lib "user32" (ByVal vKey As Integer) As Short
 
-    'Thread to check for updates
-    Private updTrd As Thread
-
-
     'Hotkeys
     Dim ctrlHeld As Boolean
     Dim oneHeld As Boolean


### PR DESCRIPTION
The online check was done in the main thread. That caused DSCM startup to be delayed if my server or the steam API is slow. This fixes that.

It also uses async/await for the updatecheck, because that makes the code more straightforward.