### PR TITLE
Add autoupdate feature

### DIFF
--- a/DaS-PC-MPChan/DSCM.vbproj
+++ b/DaS-PC-MPChan/DSCM.vbproj
@@ -77,6 +77,9 @@
     <Reference Include="CommonMark">
       <HintPath>..\packages\CommonMark.NET.0.12.0\lib\net45\CommonMark.dll</HintPath>
     </Reference>
+    <Reference Include="SharpCompress">
+      <HintPath>..\packages\sharpcompress.0.11.6\lib\net40\SharpCompress.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
@@ -129,6 +132,12 @@
     <Compile Include="SortableBindingList.vb">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="UpdateWindow.Designer.vb">
+      <DependentUpon>UpdateWindow.vb</DependentUpon>
+    </Compile>
+    <Compile Include="UpdateWindow.vb">
+      <SubType>Form</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MainWindow.resx">
@@ -139,6 +148,9 @@
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <SubType>Designer</SubType>
       <LastGenOutput>Resources.Designer.vb</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UpdateWindow.resx">
+      <DependentUpon>UpdateWindow.vb</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/DaS-PC-MPChan/DSCM.vbproj
+++ b/DaS-PC-MPChan/DSCM.vbproj
@@ -77,13 +77,11 @@
     <Reference Include="CommonMark">
       <HintPath>..\packages\CommonMark.NET.0.12.0\lib\net45\CommonMark.dll</HintPath>
     </Reference>
-    <Reference Include="SharpCompress">
-      <HintPath>..\packages\sharpcompress.0.11.6\lib\net40\SharpCompress.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />

--- a/DaS-PC-MPChan/MainWindow.Designer.vb
+++ b/DaS-PC-MPChan/MainWindow.Designer.vb
@@ -276,7 +276,7 @@ Partial Class MainWindow
         DataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
         Me.dgvFavoriteNodes.RowHeadersDefaultCellStyle = DataGridViewCellStyle6
         Me.dgvFavoriteNodes.RowHeadersVisible = False
-        Me.dgvFavoriteNodes.Size = New System.Drawing.Size(370, 450)
+        Me.dgvFavoriteNodes.Size = New System.Drawing.Size(370, 290)
         Me.dgvFavoriteNodes.TabIndex = 54
         '
         'tabRecent
@@ -325,7 +325,7 @@ Partial Class MainWindow
         DataGridViewCellStyle9.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
         Me.dgvRecentNodes.RowHeadersDefaultCellStyle = DataGridViewCellStyle9
         Me.dgvRecentNodes.RowHeadersVisible = False
-        Me.dgvRecentNodes.Size = New System.Drawing.Size(370, 450)
+        Me.dgvRecentNodes.Size = New System.Drawing.Size(370, 293)
         Me.dgvRecentNodes.TabIndex = 55
         '
         'tabDSCMNet
@@ -367,7 +367,7 @@ Partial Class MainWindow
         Me.helpView.Location = New System.Drawing.Point(3, 3)
         Me.helpView.MinimumSize = New System.Drawing.Size(20, 20)
         Me.helpView.Name = "helpView"
-        Me.helpView.Size = New System.Drawing.Size(751, 458)
+        Me.helpView.Size = New System.Drawing.Size(751, 293)
         Me.helpView.TabIndex = 0
         '
         'btnAddFavorite
@@ -512,7 +512,7 @@ Partial Class MainWindow
         DataGridViewCellStyle12.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
         Me.dgvDSCMNet.RowHeadersDefaultCellStyle = DataGridViewCellStyle12
         Me.dgvDSCMNet.RowHeadersVisible = False
-        Me.dgvDSCMNet.Size = New System.Drawing.Size(740, 425)
+        Me.dgvDSCMNet.Size = New System.Drawing.Size(740, 293)
         Me.dgvDSCMNet.TabIndex = 54
         '
         'MainWindow

--- a/DaS-PC-MPChan/MainWindow.Designer.vb
+++ b/DaS-PC-MPChan/MainWindow.Designer.vb
@@ -25,15 +25,15 @@ Partial Class MainWindow
         Dim lblNodes As System.Windows.Forms.Label
         Dim lblNodeDiv As System.Windows.Forms.Label
         Dim lblYourId As System.Windows.Forms.Label
-        Dim DataGridViewCellStyle1 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle2 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle3 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Dim DataGridViewCellStyle4 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Dim DataGridViewCellStyle5 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Dim DataGridViewCellStyle6 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Dim DataGridViewCellStyle7 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Dim DataGridViewCellStyle8 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Dim DataGridViewCellStyle9 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle1 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle2 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle3 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Dim DataGridViewCellStyle10 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Dim DataGridViewCellStyle11 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Dim DataGridViewCellStyle12 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
@@ -48,36 +48,36 @@ Partial Class MainWindow
         Me.btnAttemptId = New System.Windows.Forms.Button()
         Me.tabs = New System.Windows.Forms.TabControl()
         Me.tabActive = New System.Windows.Forms.TabPage()
-        Me.dgvMPNodes = New DSCM.ExtendedDataGridView()
         Me.tabFavorites = New System.Windows.Forms.TabPage()
         Me.dgvFavoriteNodes = New System.Windows.Forms.DataGridView()
         Me.tabRecent = New System.Windows.Forms.TabPage()
         Me.dgvRecentNodes = New System.Windows.Forms.DataGridView()
         Me.tabDSCMNet = New System.Windows.Forms.TabPage()
         Me.txtIRCDebug = New System.Windows.Forms.TextBox()
-        Me.dgvDSCMNet = New DSCM.ExtendedDataGridView()
         Me.tabHelp = New System.Windows.Forms.TabPage()
         Me.helpView = New System.Windows.Forms.WebBrowser()
         Me.btnAddFavorite = New System.Windows.Forms.Button()
         Me.btnRemFavorite = New System.Windows.Forms.Button()
         Me.lblNewVersion = New System.Windows.Forms.Label()
-        Me.lblUrl = New System.Windows.Forms.Label()
         Me.chkDSCMNet = New System.Windows.Forms.CheckBox()
         Me.dsProcessStatus = New System.Windows.Forms.TextBox()
+        Me.btnUpdate = New System.Windows.Forms.Button()
+        Me.dgvMPNodes = New DSCM.ExtendedDataGridView()
+        Me.dgvDSCMNet = New DSCM.ExtendedDataGridView()
         lblNodes = New System.Windows.Forms.Label()
         lblNodeDiv = New System.Windows.Forms.Label()
         lblYourId = New System.Windows.Forms.Label()
         CType(Me.nmbMaxNodes, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.tabs.SuspendLayout()
         Me.tabActive.SuspendLayout()
-        CType(Me.dgvMPNodes, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.tabFavorites.SuspendLayout()
         CType(Me.dgvFavoriteNodes, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.tabRecent.SuspendLayout()
         CType(Me.dgvRecentNodes, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.tabDSCMNet.SuspendLayout()
-        CType(Me.dgvDSCMNet, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.tabHelp.SuspendLayout()
+        CType(Me.dgvMPNodes, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.dgvDSCMNet, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
         '
         'lblNodes
@@ -229,46 +229,6 @@ Partial Class MainWindow
         Me.tabActive.TabIndex = 0
         Me.tabActive.Text = "Active"
         '
-        'dgvMPNodes
-        '
-        Me.dgvMPNodes.AllowUserToAddRows = False
-        Me.dgvMPNodes.AllowUserToDeleteRows = False
-        Me.dgvMPNodes.AllowUserToResizeRows = False
-        Me.dgvMPNodes.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
-            Or System.Windows.Forms.AnchorStyles.Left) _
-            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        DataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control
-        DataGridViewCellStyle1.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText
-        DataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.dgvMPNodes.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle1
-        Me.dgvMPNodes.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
-        DataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window
-        DataGridViewCellStyle2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText
-        DataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
-        Me.dgvMPNodes.DefaultCellStyle = DataGridViewCellStyle2
-        Me.dgvMPNodes.Location = New System.Drawing.Point(6, 6)
-        Me.dgvMPNodes.Name = "dgvMPNodes"
-        Me.dgvMPNodes.ReadOnly = True
-        DataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control
-        DataGridViewCellStyle3.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText
-        DataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.dgvMPNodes.RowHeadersDefaultCellStyle = DataGridViewCellStyle3
-        Me.dgvMPNodes.RowHeadersVisible = False
-        Me.dgvMPNodes.Size = New System.Drawing.Size(740, 288)
-        Me.dgvMPNodes.TabIndex = 53
-        '
         'tabFavorites
         '
         Me.tabFavorites.BackColor = System.Drawing.SystemColors.Control
@@ -388,46 +348,6 @@ Partial Class MainWindow
         Me.txtIRCDebug.Size = New System.Drawing.Size(740, 20)
         Me.txtIRCDebug.TabIndex = 55
         '
-        'dgvDSCMNet
-        '
-        Me.dgvDSCMNet.AllowUserToAddRows = False
-        Me.dgvDSCMNet.AllowUserToDeleteRows = False
-        Me.dgvDSCMNet.AllowUserToResizeRows = False
-        Me.dgvDSCMNet.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
-            Or System.Windows.Forms.AnchorStyles.Left) _
-            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        DataGridViewCellStyle10.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle10.BackColor = System.Drawing.SystemColors.Control
-        DataGridViewCellStyle10.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle10.ForeColor = System.Drawing.SystemColors.WindowText
-        DataGridViewCellStyle10.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle10.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle10.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.dgvDSCMNet.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle10
-        Me.dgvDSCMNet.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
-        DataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle11.BackColor = System.Drawing.SystemColors.Window
-        DataGridViewCellStyle11.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle11.ForeColor = System.Drawing.SystemColors.ControlText
-        DataGridViewCellStyle11.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle11.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle11.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
-        Me.dgvDSCMNet.DefaultCellStyle = DataGridViewCellStyle11
-        Me.dgvDSCMNet.Location = New System.Drawing.Point(6, 6)
-        Me.dgvDSCMNet.Name = "dgvDSCMNet"
-        Me.dgvDSCMNet.ReadOnly = True
-        DataGridViewCellStyle12.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle12.BackColor = System.Drawing.SystemColors.Control
-        DataGridViewCellStyle12.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle12.ForeColor = System.Drawing.SystemColors.WindowText
-        DataGridViewCellStyle12.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle12.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle12.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.dgvDSCMNet.RowHeadersDefaultCellStyle = DataGridViewCellStyle12
-        Me.dgvDSCMNet.RowHeadersVisible = False
-        Me.dgvDSCMNet.Size = New System.Drawing.Size(740, 425)
-        Me.dgvDSCMNet.TabIndex = 54
-        '
         'tabHelp
         '
         Me.tabHelp.Controls.Add(Me.helpView)
@@ -477,24 +397,12 @@ Partial Class MainWindow
         Me.lblNewVersion.AutoSize = True
         Me.lblNewVersion.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.lblNewVersion.ForeColor = System.Drawing.Color.Red
-        Me.lblNewVersion.Location = New System.Drawing.Point(9, 76)
+        Me.lblNewVersion.Location = New System.Drawing.Point(9, 72)
         Me.lblNewVersion.Name = "lblNewVersion"
         Me.lblNewVersion.Size = New System.Drawing.Size(183, 16)
         Me.lblNewVersion.TabIndex = 71
         Me.lblNewVersion.Text = "New testing version available"
         Me.lblNewVersion.Visible = False
-        '
-        'lblUrl
-        '
-        Me.lblUrl.AutoSize = True
-        Me.lblUrl.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.lblUrl.ForeColor = System.Drawing.Color.Red
-        Me.lblUrl.Location = New System.Drawing.Point(9, 93)
-        Me.lblUrl.Name = "lblUrl"
-        Me.lblUrl.Size = New System.Drawing.Size(94, 16)
-        Me.lblUrl.TabIndex = 72
-        Me.lblUrl.Text = "http://wulf2k.ca"
-        Me.lblUrl.Visible = False
         '
         'chkDSCMNet
         '
@@ -517,14 +425,104 @@ Partial Class MainWindow
         Me.dsProcessStatus.Size = New System.Drawing.Size(187, 20)
         Me.dsProcessStatus.TabIndex = 74
         '
+        'btnUpdate
+        '
+        Me.btnUpdate.Location = New System.Drawing.Point(10, 88)
+        Me.btnUpdate.Name = "btnUpdate"
+        Me.btnUpdate.Size = New System.Drawing.Size(182, 23)
+        Me.btnUpdate.TabIndex = 75
+        Me.btnUpdate.Text = "Update DSCM"
+        Me.btnUpdate.UseVisualStyleBackColor = True
+        Me.btnUpdate.Visible = False
+        '
+        'dgvMPNodes
+        '
+        Me.dgvMPNodes.AllowUserToAddRows = False
+        Me.dgvMPNodes.AllowUserToDeleteRows = False
+        Me.dgvMPNodes.AllowUserToResizeRows = False
+        Me.dgvMPNodes.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        DataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control
+        DataGridViewCellStyle1.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.dgvMPNodes.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle1
+        Me.dgvMPNodes.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        DataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window
+        DataGridViewCellStyle2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText
+        DataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
+        Me.dgvMPNodes.DefaultCellStyle = DataGridViewCellStyle2
+        Me.dgvMPNodes.Location = New System.Drawing.Point(6, 6)
+        Me.dgvMPNodes.Name = "dgvMPNodes"
+        Me.dgvMPNodes.ReadOnly = True
+        DataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control
+        DataGridViewCellStyle3.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.dgvMPNodes.RowHeadersDefaultCellStyle = DataGridViewCellStyle3
+        Me.dgvMPNodes.RowHeadersVisible = False
+        Me.dgvMPNodes.Size = New System.Drawing.Size(740, 288)
+        Me.dgvMPNodes.TabIndex = 53
+        '
+        'dgvDSCMNet
+        '
+        Me.dgvDSCMNet.AllowUserToAddRows = False
+        Me.dgvDSCMNet.AllowUserToDeleteRows = False
+        Me.dgvDSCMNet.AllowUserToResizeRows = False
+        Me.dgvDSCMNet.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        DataGridViewCellStyle10.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle10.BackColor = System.Drawing.SystemColors.Control
+        DataGridViewCellStyle10.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle10.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle10.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle10.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle10.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.dgvDSCMNet.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle10
+        Me.dgvDSCMNet.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        DataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle11.BackColor = System.Drawing.SystemColors.Window
+        DataGridViewCellStyle11.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle11.ForeColor = System.Drawing.SystemColors.ControlText
+        DataGridViewCellStyle11.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle11.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle11.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
+        Me.dgvDSCMNet.DefaultCellStyle = DataGridViewCellStyle11
+        Me.dgvDSCMNet.Location = New System.Drawing.Point(6, 6)
+        Me.dgvDSCMNet.Name = "dgvDSCMNet"
+        Me.dgvDSCMNet.ReadOnly = True
+        DataGridViewCellStyle12.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle12.BackColor = System.Drawing.SystemColors.Control
+        DataGridViewCellStyle12.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle12.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle12.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle12.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle12.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.dgvDSCMNet.RowHeadersDefaultCellStyle = DataGridViewCellStyle12
+        Me.dgvDSCMNet.RowHeadersVisible = False
+        Me.dgvDSCMNet.Size = New System.Drawing.Size(740, 425)
+        Me.dgvDSCMNet.TabIndex = 54
+        '
         'MainWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(784, 480)
+        Me.Controls.Add(Me.btnUpdate)
         Me.Controls.Add(Me.dsProcessStatus)
         Me.Controls.Add(Me.chkDSCMNet)
-        Me.Controls.Add(Me.lblUrl)
         Me.Controls.Add(Me.lblNewVersion)
         Me.Controls.Add(Me.btnRemFavorite)
         Me.Controls.Add(Me.btnAddFavorite)
@@ -546,15 +544,15 @@ Partial Class MainWindow
         CType(Me.nmbMaxNodes, System.ComponentModel.ISupportInitialize).EndInit()
         Me.tabs.ResumeLayout(False)
         Me.tabActive.ResumeLayout(False)
-        CType(Me.dgvMPNodes, System.ComponentModel.ISupportInitialize).EndInit()
         Me.tabFavorites.ResumeLayout(False)
         CType(Me.dgvFavoriteNodes, System.ComponentModel.ISupportInitialize).EndInit()
         Me.tabRecent.ResumeLayout(False)
         CType(Me.dgvRecentNodes, System.ComponentModel.ISupportInitialize).EndInit()
         Me.tabDSCMNet.ResumeLayout(False)
         Me.tabDSCMNet.PerformLayout()
-        CType(Me.dgvDSCMNet, System.ComponentModel.ISupportInitialize).EndInit()
         Me.tabHelp.ResumeLayout(False)
+        CType(Me.dgvMPNodes, System.ComponentModel.ISupportInitialize).EndInit()
+        CType(Me.dgvDSCMNet, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -576,7 +574,6 @@ Partial Class MainWindow
     Friend WithEvents dgvFavoriteNodes As DataGridView
     Friend WithEvents dgvRecentNodes As DataGridView
     Friend WithEvents lblNewVersion As Label
-    Friend WithEvents lblUrl As Label
     Friend WithEvents tabDSCMNet As TabPage
     Friend WithEvents chkDSCMNet As CheckBox
     Friend WithEvents txtIRCDebug As System.Windows.Forms.TextBox
@@ -585,4 +582,5 @@ Partial Class MainWindow
     Friend WithEvents helpView As System.Windows.Forms.WebBrowser
     Friend WithEvents dgvMPNodes As Global.DSCM.ExtendedDataGridView
     Friend WithEvents dgvDSCMNet As Global.DSCM.ExtendedDataGridView
+    Friend WithEvents btnUpdate As System.Windows.Forms.Button
 End Class

--- a/DaS-PC-MPChan/MainWindow.Designer.vb
+++ b/DaS-PC-MPChan/MainWindow.Designer.vb
@@ -343,7 +343,7 @@ Partial Class MainWindow
         '
         Me.txtIRCDebug.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.txtIRCDebug.Location = New System.Drawing.Point(6, 438)
+        Me.txtIRCDebug.Location = New System.Drawing.Point(6, 279)
         Me.txtIRCDebug.Name = "txtIRCDebug"
         Me.txtIRCDebug.Size = New System.Drawing.Size(740, 20)
         Me.txtIRCDebug.TabIndex = 55
@@ -512,7 +512,7 @@ Partial Class MainWindow
         DataGridViewCellStyle12.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
         Me.dgvDSCMNet.RowHeadersDefaultCellStyle = DataGridViewCellStyle12
         Me.dgvDSCMNet.RowHeadersVisible = False
-        Me.dgvDSCMNet.Size = New System.Drawing.Size(740, 293)
+        Me.dgvDSCMNet.Size = New System.Drawing.Size(740, 267)
         Me.dgvDSCMNet.TabIndex = 54
         '
         'MainWindow

--- a/DaS-PC-MPChan/MainWindow.vb
+++ b/DaS-PC-MPChan/MainWindow.vb
@@ -312,10 +312,6 @@ Public Class MainWindow
             End Try
         Next
     End Sub
-    Private Function versionToUrl(version As String) As String
-        Dim fileVersion = Regex.Replace(version, "^(\d{4})(\d{2})(\d{2})(\d{2})$", "$1-$2-$3-$4")
-        Return "http://wulf2k.ca/PC/DaS/DSCM-" & fileVersion & ".rar"
-    End Function
     Private Async Sub updatecheck()
         Try
             Dim client As New Net.WebClient()
@@ -323,18 +319,20 @@ Public Class MainWindow
             Dim content As String = Await client.DownloadStringTaskAsync(uri)
 
             Dim lines() As String = content.Split({vbCrLf, vbLf}, StringSplitOptions.None)
-            Dim stablever = lines(0)
-            Dim testver = lines(1)
+            Dim stableVersion = lines(0)
+            Dim stableUrl = lines(2)
+            Dim testVersion = lines(1)
+            Dim testUrl = lines(3)
 
-            If stablever > Version.Replace(".", "") Then
+            If stableVersion > Version.Replace(".", "") Then
                 lblNewVersion.Visible = True
                 btnUpdate.Visible = True
-                btnUpdate.Tag = versionToUrl(stablever)
+                btnUpdate.Tag = stableUrl
                 lblNewVersion.Text = "New stable version available"
-            ElseIf testver > Version.Replace(".", "") Then
+            ElseIf testVersion > Version.Replace(".", "") Then
                 lblNewVersion.Visible = True
                 btnUpdate.Visible = True
-                btnUpdate.Tag = versionToUrl(testver)
+                btnUpdate.Tag = testUrl
                 lblNewVersion.Text = "New testing version available"
             End If
         Catch ex As Exception

--- a/DaS-PC-MPChan/MainWindow.vb
+++ b/DaS-PC-MPChan/MainWindow.vb
@@ -322,7 +322,7 @@ Public Class MainWindow
             Dim uri = "http://wulf2k.ca/pc/das/dscm-ver.txt"
             Dim content As String = Await client.DownloadStringTaskAsync(uri)
 
-            Dim lines() As String = content.Split({Chr(10), Chr(13)})
+            Dim lines() As String = content.Split({vbCrLf, vbLf}, StringSplitOptions.None)
             Dim stablever = lines(0)
             Dim testver = lines(1)
 

--- a/DaS-PC-MPChan/MainWindow.vb
+++ b/DaS-PC-MPChan/MainWindow.vb
@@ -50,11 +50,17 @@ Public Class MainWindow
         Next
         If oldFileArg IsNot Nothing Then
             If oldFileArg.EndsWith(".old") Then
-                Try
-                    File.Delete(oldFileArg)
-                Catch ex As Exception
-                    MsgBox("Deleting old version failed: " & vbCrLf & ex.Message, MsgBoxStyle.Exclamation)
-                End Try
+                Dim t = New Thread(
+                    Sub()
+                    Try
+                        'Give the old version time to shut down
+                        Thread.Sleep(1000)
+                        File.Delete(oldFileArg)
+                    Catch ex As Exception
+                        Me.Invoke(Function() MsgBox("Deleting old version failed: " & vbCrLf & ex.Message, MsgBoxStyle.Exclamation))
+                    End Try
+                End Sub)
+                t.Start()
             Else
                 MsgBox("Deleting old version failed: Invalid filename ", MsgBoxStyle.Exclamation)
             End If

--- a/DaS-PC-MPChan/MainWindow.vb
+++ b/DaS-PC-MPChan/MainWindow.vb
@@ -38,6 +38,29 @@ Public Class MainWindow
     Private Sub DSCM_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         Version = lblVer.Text
 
+        Dim oldFileArg As String = Nothing
+        For Each arg In Environment.GetCommandLineArgs().Skip(1)
+            If arg.StartsWith("--old-file=") Then
+                oldFileArg = arg.Substring("--old-file=".Length)
+            Else
+                MsgBox("Unknown command line arguments")
+                oldFileArg = Nothing
+                Exit For
+            End If
+        Next
+        If oldFileArg IsNot Nothing Then
+            If oldFileArg.EndsWith(".old") Then
+                Try
+                    File.Delete(oldFileArg)
+                Catch ex As Exception
+                    MsgBox("Deleting old version failed: " & vbCrLf & ex.Message, MsgBoxStyle.Exclamation)
+                End Try
+            Else
+                MsgBox("Deleting old version failed: Invalid filename ", MsgBoxStyle.Exclamation)
+            End If
+        End If
+
+
         txtTargetSteamID.SetPlaceholder(txtTargetSteamID.Text)
         txtTargetSteamID.Text = ""
 
@@ -326,7 +349,7 @@ Public Class MainWindow
                 dsProcess.Dispose()
                 dsProcess = Nothing
             End If
-            Process.Start(updateWindow.NewAssembly)
+            Process.Start(updateWindow.NewAssembly, """--old-file=" & updateWindow.OldAssembly & """")
             Me.Close()
         End If
     End Sub

--- a/DaS-PC-MPChan/UpdateWindow.Designer.vb
+++ b/DaS-PC-MPChan/UpdateWindow.Designer.vb
@@ -1,0 +1,92 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class UpdateWindow
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.progress = New System.Windows.Forms.ProgressBar()
+        Me.btnCancel = New System.Windows.Forms.Button()
+        Me.statusLabel = New System.Windows.Forms.Label()
+        Me.errorDetails = New System.Windows.Forms.TextBox()
+        Me.SuspendLayout()
+        '
+        'progress
+        '
+        Me.progress.Location = New System.Drawing.Point(12, 42)
+        Me.progress.Name = "progress"
+        Me.progress.Size = New System.Drawing.Size(276, 23)
+        Me.progress.TabIndex = 0
+        '
+        'btnCancel
+        '
+        Me.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel
+        Me.btnCancel.Location = New System.Drawing.Point(213, 72)
+        Me.btnCancel.Name = "btnCancel"
+        Me.btnCancel.Size = New System.Drawing.Size(75, 23)
+        Me.btnCancel.TabIndex = 1
+        Me.btnCancel.Text = "Cancel"
+        Me.btnCancel.UseVisualStyleBackColor = True
+        '
+        'statusLabel
+        '
+        Me.statusLabel.AutoSize = True
+        Me.statusLabel.Location = New System.Drawing.Point(9, 19)
+        Me.statusLabel.Name = "statusLabel"
+        Me.statusLabel.Size = New System.Drawing.Size(61, 13)
+        Me.statusLabel.TabIndex = 2
+        Me.statusLabel.Text = "Initializing …"
+        '
+        'errorDetails
+        '
+        Me.errorDetails.BackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(200, Byte), Integer), CType(CType(200, Byte), Integer))
+        Me.errorDetails.Location = New System.Drawing.Point(13, 72)
+        Me.errorDetails.Name = "errorDetails"
+        Me.errorDetails.ReadOnly = True
+        Me.errorDetails.Size = New System.Drawing.Size(109, 20)
+        Me.errorDetails.TabIndex = 3
+        Me.errorDetails.Visible = False
+        '
+        'UpdateWindow
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(300, 107)
+        Me.Controls.Add(Me.errorDetails)
+        Me.Controls.Add(Me.statusLabel)
+        Me.Controls.Add(Me.btnCancel)
+        Me.Controls.Add(Me.progress)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.Name = "UpdateWindow"
+        Me.ShowIcon = False
+        Me.ShowInTaskbar = False
+        Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent
+        Me.Text = "Updating DSCM …"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+    Friend WithEvents progress As System.Windows.Forms.ProgressBar
+    Friend WithEvents btnCancel As System.Windows.Forms.Button
+    Friend WithEvents statusLabel As System.Windows.Forms.Label
+    Friend WithEvents errorDetails As System.Windows.Forms.TextBox
+End Class

--- a/DaS-PC-MPChan/UpdateWindow.resx
+++ b/DaS-PC-MPChan/UpdateWindow.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/DaS-PC-MPChan/UpdateWindow.vb
+++ b/DaS-PC-MPChan/UpdateWindow.vb
@@ -75,7 +75,7 @@ Public Class UpdateWindow
                 tmpFile.Write(extractedContents, 0, extractedContents.Length)
             End Using
             'Generate path in same directory to make sure we have write access there
-            Dim tmpAssemblyPath = assemblyPath & ".tmp"
+            Dim tmpAssemblyPath = assemblyPath & ".old"
             If File.Exists(tmpAssemblyPath) Then File.Delete(tmpAssemblyPath)
             File.Move(assemblyPath, tmpAssemblyPath)
             File.Move(tmpPath, assemblyPath)
@@ -94,12 +94,13 @@ Public Class UpdateWindow
         Using compressedStream As New MemoryStream(compressedContents)
             Dim reader = SharpCompress.Reader.ReaderFactory.Open(compressedStream)
             While reader.MoveToNextEntry()
-                If ignoreExtensions.Contains(Path.GetExtension(reader.Entry.Key)) Then
+                Dim entryExtension = Path.GetExtension(reader.Entry.Key).ToLower()
+                If ignoreExtensions.Contains(entryExtension) Then
                     Continue While
                 End If
                 If (extractedContents IsNot Nothing Or
                         reader.Entry.IsDirectory Or
-                        Not Path.GetExtension(reader.Entry.Key) = ".exe") Then
+                        Not entryExtension = ".exe") Then
                     Throw New ApplicationException("Unkown structure, please update manually")
                 End If
                 extractedContents = New Byte(reader.Entry.Size) {}

--- a/DaS-PC-MPChan/UpdateWindow.vb
+++ b/DaS-PC-MPChan/UpdateWindow.vb
@@ -1,0 +1,116 @@
+﻿Imports System.Net
+Imports System.IO
+Imports System.Runtime.InteropServices
+Imports System.Runtime.CompilerServices
+Imports System.Threading
+
+Public Class UpdateWindow
+    Private WithEvents client As New WebClient()
+    Private url As String
+    Private ctSource As New CancellationTokenSource()
+
+    Public WasSuccessful As Boolean = False
+    Public NewAssembly As String = Nothing
+    Public OldAssembly As String = Nothing
+    Sub New(url)
+        InitializeComponent()
+        Me.url = url
+    End Sub
+    Private Async Sub OnShow(sender As Object, e As EventArgs) Handles MyBase.Shown
+        Await doUpdate(ctSource.Token)
+        If WasSuccessful Then
+            Me.Close()
+        End If
+    End Sub
+    Private Sub CancelButton_Click(sender As Object, e As EventArgs) Handles btnCancel.Click
+        Me.Close()
+    End Sub
+    Private Sub OnClose(sender As Object, e As FormClosingEventArgs) Handles MyBase.FormClosing
+        ctSource.Cancel()
+    End Sub
+    Private Sub setStatus(message As String)
+        statusLabel.Text = message
+    End Sub
+    Private Sub setError(message As String, details As String)
+        statusLabel.Text = message
+        errorDetails.Text = " " & details
+        errorDetails.Visible = True
+        errorDetails.Size = progress.Size
+        errorDetails.Location = progress.Location
+        errorDetails.Visible = True
+        progress.Visible = False
+    End Sub
+    Private Sub DownloadProgress(sender As WebClient, e As DownloadProgressChangedEventArgs) Handles client.DownloadProgressChanged
+        progress.Value = e.ProgressPercentage
+    End Sub
+    Private Async Function doUpdate(ct As CancellationToken) As Task
+        ct.ThrowIfCancellationRequested()
+        setStatus("Downloading new version …")
+        Dim compressedContents() As Byte
+        Try
+            ct.Register(AddressOf client.CancelAsync)
+            compressedContents = Await client.DownloadDataTaskAsync(url)
+        Catch ex As Exception
+            setError("Download failed:", ex.Message)
+            Return
+        End Try
+
+        ct.ThrowIfCancellationRequested()
+        progress.Style = ProgressBarStyle.Marquee
+        setStatus("Extracting …")
+        Dim extractedContents() As Byte
+        Try
+            extractedContents = Await Task.Run(Function() extractFile(compressedContents))
+        Catch ex As Exception
+            setError("Extraction failed:", ex.Message)
+            Return
+        End Try
+
+        ct.ThrowIfCancellationRequested()
+        setStatus("Replacing executable with new version …")
+        Try
+            Dim assemblyPath = Application.ExecutablePath
+            Dim tmpPath = Path.GetTempFileName()
+            Using tmpFile = File.Open(tmpPath, FileMode.Create)
+                tmpFile.Write(extractedContents, 0, extractedContents.Length)
+            End Using
+            'Generate path in same directory to make sure we have write access there
+            Dim tmpAssemblyPath = assemblyPath & ".tmp"
+            If File.Exists(tmpAssemblyPath) Then File.Delete(tmpAssemblyPath)
+            File.Move(assemblyPath, tmpAssemblyPath)
+            File.Move(tmpPath, assemblyPath)
+            NewAssembly = assemblyPath
+            OldAssembly = tmpAssemblyPath
+        Catch ex As Exception
+            setError("Replacing old version failed:", ex.Message)
+            Return
+        End Try
+
+        WasSuccessful = True
+    End Function
+    Private Function extractFile(compressedContents() As Byte) As Byte()
+        Dim ignoreExtensions() As String = {".txt", ".doc", ".docx", ".md"}
+        Dim extractedContents() As Byte = Nothing
+        Using compressedStream As New MemoryStream(compressedContents)
+            Dim reader = SharpCompress.Reader.ReaderFactory.Open(compressedStream)
+            While reader.MoveToNextEntry()
+                If ignoreExtensions.Contains(Path.GetExtension(reader.Entry.Key)) Then
+                    Continue While
+                End If
+                If (extractedContents IsNot Nothing Or
+                        reader.Entry.IsDirectory Or
+                        Not Path.GetExtension(reader.Entry.Key) = ".exe") Then
+                    Throw New ApplicationException("Unkown structure, please update manually")
+                End If
+                extractedContents = New Byte(reader.Entry.Size) {}
+                Using extractedStream = reader.OpenEntryStream()
+                    extractedStream.Read(extractedContents, 0, reader.Entry.Size)
+                End Using
+            End While
+        End Using
+        If extractedContents Is Nothing Then
+            Throw New ApplicationException("Unkown structure, please update manually")
+        End If
+        Return extractedContents
+    End Function
+End Class

--- a/DaS-PC-MPChan/UpdateWindow.vb
+++ b/DaS-PC-MPChan/UpdateWindow.vb
@@ -102,7 +102,7 @@ Public Class UpdateWindow
                 'Apart from the ignored file types, the archive should contain
                 'exactly one executable
                 If extractedContents IsNot Nothing Or Not entryExtension = ".exe" Then
-                    Throw New ApplicationException("Unkown structure, please update manually")
+                    Throw New ApplicationException("Unknown structure, please update manually")
                 End If
                 extractedContents = New Byte(entry.Length) {}
                 Using extractedStream = entry.Open()
@@ -111,7 +111,7 @@ Public Class UpdateWindow
             Next
         End Using
         If extractedContents Is Nothing Then
-            Throw New ApplicationException("Unkown structure, please update manually")
+            Throw New ApplicationException("Unknown structure, please update manually")
         End If
         Return extractedContents
     End Function

--- a/DaS-PC-MPChan/packages.config
+++ b/DaS-PC-MPChan/packages.config
@@ -3,4 +3,5 @@
   <package id="CommonMark.NET" version="0.12.0" targetFramework="net45" />
   <package id="ILMerge" version="2.13.0307" targetFramework="net45" />
   <package id="MSBuild.ILMerge.Task" version="1.0.2" targetFramework="net45" />
+  <package id="sharpcompress" version="0.11.6" targetFramework="net45" />
 </packages>

--- a/DaS-PC-MPChan/packages.config
+++ b/DaS-PC-MPChan/packages.config
@@ -3,5 +3,4 @@
   <package id="CommonMark.NET" version="0.12.0" targetFramework="net45" />
   <package id="ILMerge" version="2.13.0307" targetFramework="net45" />
   <package id="MSBuild.ILMerge.Task" version="1.0.2" targetFramework="net45" />
-  <package id="sharpcompress" version="0.11.6" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
That was a bit of work, but it's done :).

There are some ways how this could be improved on the server-side:
* The executable just grew to 1MB because the library that extracts rar files is 700kb. If you would pack your releases as zip files, we could use core library code instead.
* Building the download url from the version string does not feel very good. We should send the urls in the version file. Probably line 3 and 4?

It also very important that you do not add the version to the filename of the executable inside the `rar` in future releases, as that filename will be wrong after the first autoupdate.

If you want to make the relevant changes on the server side, do them and tell me, then I will update this code.