### PR TITLE
Fix NullReferenceException in DarkSoulsProcess (fixes #85)

### DIFF
--- a/DaS-PC-MPChan/DarkSoulsProcess.vb
+++ b/DaS-PC-MPChan/DarkSoulsProcess.vb
@@ -161,7 +161,8 @@ Public Class DarkSoulsProcess
                     dsBase = dll.BaseAddress
 
                 Case "d3d9.dll"
-                    If dll.FileVersionInfo.ProductName.Contains("Watchdog") Then
+                    If (dll.FileVersionInfo.ProductName IsNot Nothing AndAlso
+                            dll.FileVersionInfo.ProductName.Contains("Watchdog")) Then
                         watchdogBase = dll.BaseAddress
                     End If
 


### PR DESCRIPTION
This fixes #85. Next time I should probably read [the docs](https://msdn.microsoft.com/en-us/library/system.diagnostics.fileversioninfo.productname%28v=vs.110%29.aspx) properly. But well, their example contains the same error ^^.

So what happened? People replaced their `d3d9.dll` with one that is neither the default nor pvp watchdog. And their `d3d9.dll` does not contain version information, so `ProductName` is `Nothing`. Calling `.Contains()` on that throws the exception.