### PR TITLE
Improved low FPS disconnect patch

### DIFF
--- a/DaS-PC-MPChan/DarkSoulsProcess.vb
+++ b/DaS-PC-MPChan/DarkSoulsProcess.vb
@@ -224,8 +224,8 @@ Public Class DarkSoulsProcess
         If steamApiBase = 0 Then Throw New DSProcessAttachException("Couldn't find Steam API base address")
     End Sub
     Private Sub disableLowFPSDisonnect()
-        If ReadUInt8(dsBase + &H978425) = &HE8& Then
-            WriteBytes(dsBase + &H978425, {&H90, &H90, &H90, &H90, &H90})
+        If ReadUInt8(dsBase + &HAFC39F) = &H74& Then
+            WriteBytes(dsBase + &HAFC39F, {&HEB})
         End If
     End Sub
     Private Sub detachFromProcess()


### PR DESCRIPTION
The original patch still caused you to go into offline mode when you returned to the main menu if your FPS dropped in-game. Changing a conditional jump to a mandatory jump upstream of where the original patch is applied means that the value that is checked when you return to the main menu is unaltered and it won't put you in offline mode due to low FPS.