### PR TITLE
Report Steam Matchmaking Lobbies to dscmnet

### DIFF
--- a/DaS-PC-MPChan/ASM/ASM-NodeDump.txt
+++ b/DaS-PC-MPChan/ASM/ASM-NodeDump.txt
@@ -55,5 +55,3 @@ pop edx
 pop ecx
 pop ebx
 pop eax
-movq [esi+14],xmm0
-jmp darksouls.exe+7E6383

--- a/DaS-PC-MPChan/ASM/LobbyDump.txt
+++ b/DaS-PC-MPChan/ASM/LobbyDump.txt
@@ -1,0 +1,74 @@
+Beginning:
+push eax
+push ebx
+push ecx
+push edx
+push esi
+
+// eax starts with the source adress
+// ecx := Beginning + 0x200
+call GetAddress
+GetAddress:
+pop ebx
+sub ebx, OFFSET FLAT: GetAddress
+add ebx, OFFSET FLAT: Beginning
+add ebx, 0x200
+
+mov esi, DWORD PTR [eax+8]
+mov ecx, DWORD PTR [eax+4]
+mov eax, esi
+sub eax, ecx
+cmp eax, 1600
+jne Return
+
+LoopStart:
+cmp esi, ecx
+jbe Return
+mov eax, DWORD PTR [ecx+24]
+mov edx, DWORD PTR [ecx+28]
+add ebx, 8
+add ecx, 32
+mov DWORD PTR [ebx-8], eax
+mov DWORD PTR [ebx-4], edx
+jmp LoopStart
+
+Return:
+pop esi
+pop edx
+pop ecx
+pop ebx
+pop eax
+
+
+
+Based on this C code:
+#include <stddef.h>
+#include <cstdint>
+
+
+struct xvector {
+    int f0;
+    void* startPtr;
+    void* endPtr;
+    void* bufferEndPtr;
+};
+
+struct LobbyMemberInfo {
+    xvector list;
+    int fa;
+    int fb;
+    int64_t ownerId;
+};
+
+
+void func(xvector* lobbyList, int64_t* dumpBuffer) {
+    int length = (LobbyMemberInfo*)lobbyList->endPtr - (LobbyMemberInfo*)lobbyList->startPtr;
+    if (length != 50) return;
+    int64_t* dumpPtr = dumpBuffer;
+    LobbyMemberInfo* lobbyPtr = (LobbyMemberInfo*)lobbyList->startPtr;
+    while(lobbyPtr < (LobbyMemberInfo*)lobbyList->endPtr){
+        *dumpPtr = lobbyPtr->ownerId;
+        dumpPtr++;
+        lobbyPtr++;
+    }
+};

--- a/DaS-PC-MPChan/DarkSoulsProcess.vb
+++ b/DaS-PC-MPChan/DarkSoulsProcess.vb
@@ -69,35 +69,54 @@ Public Class JmpHook
     Implements IDisposable
     Private _process As IntPtr
     Private _hookLocation As IntPtr
+    Private _jmpTarget As Intptr
     Private _oldInstructions As Byte()
 
     Private Declare Function ReadProcessMemory Lib "kernel32" (ByVal hProcess As IntPtr, ByVal lpBaseAddress As IntPtr, ByVal lpBuffer() As Byte, ByVal iSize As Integer, ByRef lpNumberOfBytesRead As Integer) As Boolean
     Private Declare Function WriteProcessMemory Lib "kernel32" (ByVal hProcess As IntPtr, ByVal lpBaseAddress As IntPtr, ByVal lpBuffer() As Byte, ByVal iSize As Integer, ByRef lpNumberOfBytesWritten As Integer) As Boolean
 
-    Sub New(targetProcessHandle As IntPtr, hookLocation As IntPtr, jmpTarget As IntPtr)
+    Sub New(targetProcessHandle As IntPtr, hookLocation As IntPtr, jmpTarget As IntPtr, Optional hookInstructionSize As UInt32 = 5)
+        Debug.Assert(hookInstructionSize >= 5)
         _process = targetProcessHandle
         _hookLocation = hookLocation
-        _oldInstructions = New Byte(4) {}
-        ReadProcessMemory(_process, _hookLocation, _oldInstructions, 5, vbNull)
+        _jmpTarget = jmpTarget
+        _oldInstructions = New Byte(hookInstructionSize-1) {}
+        ReadProcessMemory(_process, _hookLocation, _oldInstructions, hookInstructionSize, vbNull)
+
+        Dim jmpOffset As Int32 = _jmpTarget - hookLocation - 5
         Dim jmpInstruction() As Byte = {&HE9}
-        Dim jmpOffset As Int32 = jmpTarget - hookLocation - 5
-        Dim instruction() As Byte = jmpInstruction.Concat(BitConverter.GetBytes(jmpOffset)).ToArray()
-        WriteProcessMemory(_process, _hookLocation, instruction, 5, vbNull)
+        jmpInstruction = jmpInstruction.Concat(BitConverter.GetBytes(jmpOffset)).ToArray()
+
+        Dim nopInstruction As Byte = &H90
+        Dim replaceWith() As Byte = jmpInstruction.Concat(Enumerable.Repeat(nopInstruction, hookInstructionSize - 5)).ToArray()
+        WriteProcessMemory(_process, _hookLocation, replaceWith, replaceWith.Length, vbNull)
     End Sub
     Public Overloads Sub Dispose() Implements IDisposable.Dispose
         If _hookLocation <> 0 Then
-             WriteProcessMemory(_process, _hookLocation, _oldInstructions, 5, vbNull)
+             WriteProcessMemory(_process, _hookLocation, _oldInstructions, _oldInstructions.Length, vbNull)
             _hookLocation = 0
         End If
     End Sub
     Protected Overrides Sub Finalize()
         Dispose()
     End Sub
-    Public Shared Sub Permanent(targetProcessHandle As IntPtr, hookLocation As IntPtr, jmpTarget As IntPtr)
-        Dim hook As New JmpHook(targetProcessHandle, hookLocation, jmpTarget)
+    Public Shared Sub Permanent(targetProcessHandle As IntPtr, hookLocation As IntPtr, jmpTarget As IntPtr, Optional hookInstructionSize As UInt32 = 5)
+        Dim hook As New JmpHook(targetProcessHandle, hookLocation, jmpTarget, hookInstructionSize)
         'Disable cleanup
         hook._hookLocation = 0
     End Sub
+    Public Function PatchCode(code() As Byte) As Byte()
+        Dim patchedCode = code.Concat(_oldInstructions)
+
+        ' This is JmpTargetAdress - JmpSourcePositon (address after the jmp)
+        Dim returnAddress = BitConverter.GetBytes(
+            CType((_hookLocation + _oldInstructions.Length) -
+                  (_jmpTarget + code.Length + _oldInstructions.Length + 5),
+                Int32))
+        patchedCode = patchedCode.Concat({&HE9}) 'JMP
+        patchedCode = patchedCode.Concat(returnAddress)
+        Return patchedCode.ToArray()
+    End Function
 End Class
 
 
@@ -126,6 +145,8 @@ Public Class DarkSoulsProcess
     Private namedNodeHook As JmpHook
     Private nodeDumpMemory As AllocatedMemory
     Private nodeDumpHook As JmpHook
+    Private lobbyDumpMemory As AllocatedMemory
+    Private lobbyDumpHook As JmpHook
     Private connectMemory As AllocatedMemory
 
     'Dark Souls
@@ -157,6 +178,7 @@ Public Class DarkSoulsProcess
             InstallNamecrashFix()
         End If
         SetupNodeDumpHook()
+        SetupLobbyDumpHook()
     End Sub
 
     Public Overloads Sub Dispose() Implements IDisposable.Dispose
@@ -170,6 +192,7 @@ Public Class DarkSoulsProcess
                 connectMemory = Nothing
             End If
             DrawNodes = False
+            TearDownLobbyDumpHook()
             TearDownNodeDumpHook()
             detachFromProcess()
             disposed = True
@@ -372,6 +395,34 @@ Public Class DarkSoulsProcess
         For Each hookLocation In hookLocations
             JmpHook.Permanent(_targetProcessHandle, (dsBase + hookLocation.Key), (memory.address + hookLocation.Value))
         Next
+    End Sub
+    Private Sub SetupLobbyDumpHook()
+        'ASM in ASM\ASM-LobbyDump.txt
+        Dim code() As Byte = {
+            &H50, &H53, &H51, &H52, &H56, &HE8, &H00, &H00, &H00, &H00, &H5B, &H81, &HEB, &H0A, &H00, &H00,
+            &H00, &H81, &HC3, &H00, &H00, &H00, &H00, &H81, &HC3, &H00, &H02, &H00, &H00, &H8B, &H70, &H08,
+            &H8B, &H48, &H04, &H89, &HF0, &H29, &HC8, &H3D, &H40, &H06, &H00, &H00, &H75, &H18, &H39, &HCE,
+            &H76, &H14, &H8B, &H41, &H18, &H8B, &H51, &H1C, &H83, &HC3, &H08, &H83, &HC1, &H20, &H89, &H43,
+            &HF8, &H89, &H53, &HFC, &HEB, &HE8, &H5E, &H5A, &H59, &H5B, &H58
+        }
+
+
+        Dim bufferSize = &H200 + 8*50
+        Dim hookLoc As IntPtr = dsBase + &H323A0D
+        lobbyDumpMemory = New AllocatedMemory(_targetProcessHandle, bufferSize)
+        lobbyDumpHook = New JmpHook(_targetProcessHandle, hookLoc, lobbyDumpMemory, 7)
+        code = lobbyDumpHook.PatchCode(code)
+        WriteProcessMemory(_targetProcessHandle, lobbyDumpMemory, code, bufferSize, 0)
+    End Sub
+    Private Sub TearDownLobbyDumpHook()
+        If lobbyDumpHook IsNot Nothing THen
+            lobbyDumpHook.Dispose()
+            lobbyDumpHook = Nothing
+        End If
+        If lobbyDumpMemory IsNot Nothing Then
+            lobbyDumpMemory.Dispose()
+            lobbyDumpMemory = Nothing
+        End If
     End Sub
 
     Private Sub SetupNodeDumpHook()
@@ -639,6 +690,18 @@ Public Class DarkSoulsProcess
         SelfNode.Indictments = ReadInt32(heroPtr + &HEC)
         SelfNode.Covenant = ReadInt8(heroPtr + &H10B)
     End Sub
+    Public Function ReadLobbyList As List(Of UInt64)
+        Dim outList As New List(Of UInt64)
+        Dim steamIdPtr As IntPtr
+        For i = 1 To 50
+            steamIdPtr = lobbyDumpMemory.address + &H200 + 8 * (i-1)
+            If steamIdPtr = 0 Then
+                Exit For
+            End If
+            outList.Add(ReadUInt64(steamIdPtr))
+        Next
+        Return outList
+    End Function
     Public ReadOnly Property HasDarkmoonRingEquipped As Boolean
         Get
             Dim heroPtr As IntPtr = ReadIntPtr(dsBase + &HF78700)

--- a/DaS-PC-MPChan/MainWindow.vb
+++ b/DaS-PC-MPChan/MainWindow.vb
@@ -663,7 +663,7 @@ Public Class MainWindow
     End Sub
     Private Async Sub publishNodes() Handles publishNodesTimer.Tick
         If _netClient IsNot Nothing AndAlso dsProcess IsNot Nothing AndAlso dsProcess.SelfNode.SteamId IsNot Nothing Then
-            Await _netClient.publishLocalNodes(dsProcess.SelfNode, dsProcess.ConnectedNodes.Values())
+            Await _netClient.publishLocalNodes(dsProcess.SelfNode, dsProcess.ConnectedNodes.Values(), dsProcess.ReadLobbyList())
         End If
     End Sub
     Private Shared Sub hotkeyTimer_Tick() Handles hotkeyTimer.Tick

--- a/DaS-PC-MPChan/NetClient.vb
+++ b/DaS-PC-MPChan/NetClient.vb
@@ -24,10 +24,11 @@ Public Class NetClient
         content.Headers.ContentType = New Headers.MediaTypeHeaderValue("application/json")
         Return content
     End Function
-    Public Async Function publishLocalNodes(self As DSNode, nodes As IEnumerable(Of DSNode)) As Task
+    Public Async Function publishLocalNodes(self As DSNode, nodes As IEnumerable(Of DSNode), onlineSteamIds As List(Of UInt64)) As Task
         Dim data As New Dictionary(Of String, Object)() From {
             {"self", self},
-            {"nodes", nodes}
+            {"nodes", nodes},
+            {"online_ids", onlineSteamIds}
         }
         Dim content = JSONContent(data)
         Try


### PR DESCRIPTION
Darksouls uses the steam matchmaking features to find other players. That allows us to extract a list of online players from the game.
Unfortunately the game does not publish any information except for the player's steamid. So for now I just send this list to the dscmnet server.

Once this is rolled out we can then implement a feature that hands out steamids from this list that are not known to the dscm-net to clients, so they connect to them to gather their data.

At the moment the dscm-net has data of about half the online DS players. With these changes, we can hopefully increase that to close to 100%.