### PR TITLE
Add node watching mechanism

### DIFF
--- a/DaS-PC-MPChan/Config.vb
+++ b/DaS-PC-MPChan/Config.vb
@@ -11,6 +11,11 @@
 
     'How frequently should we connect to node from the central server?
     Public Const NetNodeConnectInterval = 10 * 1000
+    
+    'How frequently should we check our watch node?
+    Public Const CheckWatchNodeInterval = 20 * 1000
+    'How frequently should we exchange our watch node?
+    Public Const ExchangeWatchNodeInterval = 5 * 60 * 1000
 
     'How frequenlty should we check the only state of recent nodes and favourites via steam api?
     Public Const OnlineCheckInterval = 10 * 60 * 1000

--- a/DaS-PC-MPChan/NetClient.vb
+++ b/DaS-PC-MPChan/NetClient.vb
@@ -59,6 +59,17 @@ Public Class NetClient
         End Try
         Return Nothing
     End Function
+    Public Async Function getWatchId() As Task(Of String)
+        Dim response As HttpResponseMessage = Await client.GetAsync(Config.NetServerUrl & "/get_watch")
+        response.EnsureSuccessStatusCode()
+        Dim content = Await response.Content.ReadAsStringAsync()
+        Dim serializer As New JavaScriptSerializer()
+        Dim dsNodeSer As New DSNodeSerializer()
+
+        Dim data As IDictionary(Of String, Object) = serializer.Deserialize(Of Dictionary(Of String, Object))(content)
+        Dim watch As String = data("watch")
+        Return watch
+    End Function
     Private Sub setStatus(status As String)
         If mainWindow.InvokeRequired Then
             mainWindow.Invoke(New setStatusDelegate(AddressOf setStatus), {status})


### PR DESCRIPTION
This will reserve one slot and keep that slot filled with a player that we know is online, but who's info is not yet known to the dscm-net.

This should increase the dscm-net coverage and this improve node finding for the dscm users.

But it should especially improve the situation for non-dscm users, since they will now actively be picked up by the dscmnet.