### PR TITLE
Update DarkSoulsProcess.vb

### DIFF
--- a/DaS-PC-MPChan/DarkSoulsProcess.vb
+++ b/DaS-PC-MPChan/DarkSoulsProcess.vb
@@ -271,7 +271,6 @@ Public Class DarkSoulsProcess
             End Select
         Next
         If dsBase = 0 Then Throw New DSProcessAttachException("Couldn't find Dark Souls base address")
-        If steamApiBase = 0 Then Throw New DSProcessAttachException("Couldn't find Steam API base address")
     End Sub
     Private Sub disableLowFPSDisonnect()
         If ReadUInt8(dsBase + &HAFC39F) = &H74& Then


### PR DESCRIPTION
I deleted 

If steamApiBase = 0 Then Throw New DSProcessAttachException("Couldn't find Steam API base address")

because in Turkish currency (TL) one dollar means 3.50-4 TL to us and this makes Dark Souls Prepare To Die Edition's price 59 TL and because of this people often chooses pirated version (I dont choose because of this i don't have enough mney to this i am a 9th grade student) and this makes DS1 is cannot playable multiplayer. Please accept my request,this price is too expensive to me and most of my friends (59 TL is a great price for us, we can live with this money for 2 weeks.) and we can't play game online because of this. Thanks for reading (if you're reading). Lots of respects to modders/designers.